### PR TITLE
Add axis-drag moving tools, WINCH_IN/OUT, LIGHT_TOGGLE, requireHolding for clickPoints, and locale fixes

### DIFF
--- a/XML_REFERENCE.md
+++ b/XML_REFERENCE.md
@@ -1,0 +1,894 @@
+# FS25 Interactive Control — XML Reference
+
+Complete reference for configuring Interactive Control (IC) in vehicle and placeable XML files.  
+Covers all built-in features plus the `axisMovingTool`/`axisPoint` axis drag system and `WINCH_IN`/`WINCH_OUT` functions added to this fork.
+
+---
+
+## Table of Contents
+
+1. [Top-Level Structure](#1-top-level-structure)
+2. [Configurations](#2-configurations)
+3. [Outdoor Trigger](#3-outdoor-trigger)
+4. [interactiveControl (controller)](#4-interactivecontrol-controller)
+5. [Actions — How Controls Are Triggered](#5-actions--how-controls-are-triggered)
+   - [clickPoint](#clickpoint)
+   - [axisPoint](#axispoint-added)
+   - [button](#button)
+6. [Actors — What Controls Do](#6-actors--what-controls-do)
+   - [animation](#animation)
+   - [function](#function)
+   - [axisMovingTool](#axismovingtoool-added)
+   - [leverAnimation](#leveranimation-added)
+   - [objectChange](#objectchange)
+   - [dashboard](#dashboard)
+   - [dependingInteractiveControl](#dependinginteractivecontrol)
+7. [Shared Sub-Elements](#7-shared-sub-elements)
+   - [dependingMovingTool](#dependingmovingtool)
+   - [dependingMovingPart](#dependingmovingpart)
+   - [soundModifier](#soundmodifier)
+   - [configurationsRestrictions](#configurationsrestrictions)
+8. [Animation Part Blocking](#8-animation-part-blocking)
+9. [Custom Click Icons](#9-custom-click-icons)
+10. [Function Reference](#10-function-reference) — including `LIGHT_TOGGLE`
+11. [Full Example — Winch Controls](#11-full-example--winch-controls)
+12. [Full Example — Animation with Function](#12-full-example--animation-with-function)
+13. [Full Example — Axis Drag Moving Tool](#13-full-example--axis-drag-moving-tool)
+14. [Saving Behaviour](#14-saving-behaviour)
+
+---
+
+## 1. Top-Level Structure
+
+```xml
+<interactiveControl>
+    <!-- Option A: no configurations, single set of controls -->
+    <interactiveControls>
+        <outdoorTrigger ... />
+        <interactiveControl ... />
+    </interactiveControls>
+
+    <!-- Option B: multiple configurations (e.g. tied to shop config variants) -->
+    <interactiveControlConfigurations title="$l10n_someTitle">
+        <interactiveControlConfiguration>
+            <interactiveControls>
+                <outdoorTrigger ... />
+                <interactiveControl ... />
+            </interactiveControls>
+        </interactiveControlConfiguration>
+    </interactiveControlConfigurations>
+
+    <!-- Optional: register custom click icons -->
+    <registers>
+        <clickIcon name="MY_ICON" filename="path/to/icon.i3d" node="iconNode" blinkSpeed="1.0" />
+    </registers>
+</interactiveControl>
+```
+
+---
+
+## 2. Configurations
+
+Use `<interactiveControlConfigurations>` when you need different IC setups depending on a shop configuration (e.g. optional equipment). Each `<interactiveControlConfiguration>` maps to one configuration index. The `title` attribute sets the label shown in settings.
+
+To restrict a controller to specific configuration indices, use `<configurationsRestrictions>` inside the controller (see [§7](#7-shared-sub-elements)).
+
+---
+
+## 3. Outdoor Trigger
+
+Defines the volume in which a player on foot can activate outdoor IC click points. Required for any `type="OUTDOOR"` or `type="INDOOR_OUTDOOR"` action.
+
+```xml
+<outdoorTrigger
+    node="0>3|0"
+    linkNode="0>3|0"
+    filename="SHARED_INTERACTIVE_TRIGGER"
+    rotation="0 0 0"
+    translation="0 0 0"
+    width="5"
+    height="3"
+    length="8"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | Existing trigger node in the i3d. Use either `node` or `linkNode`+`filename`. |
+| `linkNode` | node | — | Parent node to attach a loaded trigger to. |
+| `filename` | string | — | Path to trigger i3d, or `SHARED_INTERACTIVE_TRIGGER` to use the mod's built-in trigger. |
+| `rotation` | vec3 | — | Local rotation (degrees) of the loaded trigger. |
+| `translation` | vec3 | — | Local translation of the loaded trigger. |
+| `width` | float | `5` | Trigger width (X scale). |
+| `height` | float | `3` | Trigger height (Y scale). |
+| `length` | float | `8` | Trigger length (Z scale). |
+
+**Tip:** `SHARED_INTERACTIVE_TRIGGER` is the easiest option. Set `linkNode` to a node centred on the vehicle, then tune `width`/`height`/`length` to cover the relevant area.
+
+---
+
+## 4. interactiveControl (controller)
+
+Each `<interactiveControl>` is one interactive controller — a pairing of one or more actions (how it's triggered) with one or more actors (what it does).
+
+```xml
+<interactiveControl
+    posText="Open"
+    negText="Close"
+    enabled="true"
+    analog="false"
+    analogSpeed="0.04"
+    allowsSaving="true"
+>
+    <!-- actions and actors go here -->
+</interactiveControl>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `posText` | l10n string | `$l10n_actionIC_activate` | HUD text shown when control moves to positive state (state → 1). |
+| `negText` | l10n string | `$l10n_actionIC_deactivate` | HUD text shown when control moves to negative state (state → 0). |
+| `enabled` | bool | `true` | Whether this controller is active. |
+| `analog` | bool | `false` | Enables analog (incremental) mode. See below. |
+| `analogSpeed` | float | `0.04` | Step size per click in analog mode (0–1). `1.0` = full travel in one click. |
+| `allowsSaving` | bool | `true` | Whether the controller's state is saved to the savegame. Automatically forced to `false` when using `function` or `axisMovingTool` actors (they have no persistent state). |
+
+#### Analog mode explained
+
+In the default (non-analog) mode a click **toggles** the state between exactly `0` and `1` — one click plays the animation fully open, the next plays it fully closed.
+
+With `analog="true"` each click **nudges** the state value by `analogSpeed` in the `direction` specified by whichever click point was used. The state is a float that clamps between `0.0` and `1.0`, so the animation moves in small steps.
+
+`direction` on a `clickPoint` controls which way that icon nudges the state:
+- `direction="1"` — increments toward `1.0` (forward / open / deploy)
+- `direction="-1"` — decrements toward `0.0` (reverse / close / retract)
+
+The typical pattern is **two click points on the same controller** pointing in opposite directions:
+
+```xml
+<!-- Vent that opens/closes in 5 clicks either way -->
+<interactiveControl posText="Open Vent" negText="Close Vent" analog="true" analogSpeed="0.2">
+    <clickPoint node="ventOpenBtn" type="INDOOR" iconType="ARROW" direction="1"  />
+    <clickPoint node="ventCloseBtn" type="INDOOR" iconType="ARROW" direction="-1" />
+    <animation name="openVent" speedScale="1.0" />
+</interactiveControl>
+```
+
+With `analogSpeed="1.0"` and a single click point at `direction="1"` the control behaves like a one-way deploy — one click drives the animation from wherever it is all the way to `1.0`, and the state stays there until something else moves it.
+
+---
+
+## 5. Actions — How Controls Are Triggered
+
+An action defines *how* the controller is activated. Most controllers use a `clickPoint` or `axisPoint`. Buttons are an alternative for proximity key-press triggers.
+
+### clickPoint
+
+A 2D icon projected onto the screen that the player clicks with the mouse. Supports both indoor and outdoor use.
+
+```xml
+<clickPoint
+    node="0>5|2"
+    linkNode="0>5|2"
+    rotation="0 0 0"
+    translation="0 0 0"
+    type="OUTDOOR"
+    iconType="CROSS"
+    size="0.04"
+    scaleOffset="0.004"
+    blinkSpeedScale="1"
+    alignToCamera="true"
+    invertX="false"
+    invertZ="false"
+    requireHolding="false"
+    color="0.518 0.667 0.063"
+    intensity="1.0"
+    animName="string"
+    animMinLimit="0.0"
+    animMaxLimit="1.0"
+    foldMinLimit="0.0"
+    foldMaxLimit="1.0"
+    forcedStateValue="float"
+    direction="1"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | The i3d node the click icon is positioned at. Use `node` or `linkNode`. |
+| `linkNode` | node | — | Alternative positioning node (used with `rotation`/`translation` offset). |
+| `rotation` | vec3 | — | Local rotation offset when using `linkNode`. |
+| `translation` | vec3 | — | Local translation offset when using `linkNode`. |
+| `type` | string | — | **Required.** Where the click icon is active: `INDOOR`, `OUTDOOR`, or `INDOOR_OUTDOOR`. |
+| `iconType` | string | `CROSS` | Icon shape. See icon table below. |
+| `size` | float | `0.04` | Base display size of the icon. |
+| `scaleOffset` | float | `size/10` | Amount the icon pulses up/down from `size` when hovered. |
+| `blinkSpeedScale` | float | `1` | Speed multiplier for the hover pulse animation. |
+| `alignToCamera` | bool | `true` | Rotates the icon to always face the camera. |
+| `invertX` | bool | `false` | Mirrors the icon on the X axis. |
+| `invertZ` | bool | `false` | Mirrors the icon on the Z axis. |
+| `requireHolding` | bool | `false` | When true, the action only fires while the button is held. Release stops the animation at the current position. Use with `animation returnOnRelease` or `WINCH_IN`/`WINCH_OUT` functions. |
+| `requiresEngine` | bool | `false` | When true, clicking the icon while the engine is off shows a "please start the engine first" warning popup and does nothing. The icon stays visible regardless. |
+| `color` | vec3 | IC green | RGB color for the icon as normalized floats (0–1). Default is the standard IC green (`0.518 0.667 0.063` = RGB 132 170 16). Examples: `1 0 0` = red, `0 0.8 0` = green, `0 0 1` = blue, `1 1 1` = white. |
+| `intensity` | float | `1.0` | Emissive brightness multiplier (0–20). Higher values make the configured color more vivid and dark colors appear darker. `1.0` matches the original IC icon brightness. |
+| `animName` | string | — | Restricts this click point to only show when the named animation is within `animMinLimit`–`animMaxLimit`. |
+| `animMinLimit` | float | `0.0` | Minimum animation time (0–1) for visibility restriction. |
+| `animMaxLimit` | float | `1.0` | Maximum animation time (0–1) for visibility restriction. |
+| `foldMinLimit` | float | `0.0` | Minimum fold time for visibility restriction. |
+| `foldMaxLimit` | float | `1.0` | Maximum fold time for visibility restriction. |
+| `forcedStateValue` | float | — | Forces the controller to this exact state value when clicked, instead of toggling. |
+| `direction` | float | `1` | In analog mode: `1` nudges state toward 1.0, `-1` nudges toward 0.0. No effect in toggle mode. See [Analog mode explained](#analog-mode-explained). |
+
+**Available icon types:**
+
+| Icon | Description |
+|---|---|
+| `CROSS` | Generic crosshair / interact |
+| `IGNITIONKEY` | Engine key |
+| `CRUISE_CONTROL` | Cruise control |
+| `GPS` | GPS / auto-steering |
+| `TURN_ON` | Power / on-off |
+| `ATTACHERJOINTS_LOWER` | Lower attacher |
+| `ATTACHERJOINTS_LIFT` | Raise attacher |
+| `ATTACHERJOINT` | Attacher joint |
+| `LIGHT` | Lights |
+| `LIGHT_HIGH` | High beam |
+| `TURNLIGHT_LEFT` | Left indicator |
+| `TURNLIGHT_RIGHT` | Right indicator |
+| `BEACON_LIGHT` | Beacon / strobe |
+| `ARROW` | Generic arrow |
+| `PIPE_FOLDING` | Pipe fold |
+
+---
+
+### axisPoint *(added)*
+
+An extension of `clickPoint` for **axis drag** controls. The player holds the button and moves the mouse to drive a moving tool. Always requires holding — no separate `requireHolding` attribute needed.
+
+Used together with the `axisMovingTool` actor.
+
+```xml
+<axisPoint
+    node="0>5|2"
+    type="OUTDOOR"
+    iconType="CROSS"
+    size="0.04"
+    alignToCamera="true"
+    sensitivity="1.0"
+    dragAxis="Y"
+    color="0.518 0.667 0.063"
+    intensity="1.0"
+/>
+```
+
+Inherits **all** `clickPoint` attributes (including `color`, `intensity`, `animName` limits, etc.). Additional attributes:
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `sensitivity` | float | `1.0` | Speed multiplier relative to in-vehicle mouse dragging. `1.0` = identical feel. `0.5` = half speed, `2.0` = twice as fast. |
+| `dragAxis` | string | `Y` | Which mouse axis drives the tool. `Y` = up/down (default). `X` = left/right. |
+
+**Notes:**
+- `requireHolding` is implicit — you do not need to set it.
+- Add `requiresEngine="true"` if the drag hold should require the engine to be running. When set and the engine is off, a "please start the engine first" popup is shown.
+- Camera rotation on the chosen drag axis is suppressed while dragging.
+
+---
+
+### button
+
+A proximity-based key-press trigger. When the player is within `range` of `refNode`, pressing `input` activates the controller. Works indoors and outdoors.
+
+```xml
+<button
+    input="IC_CLICK"
+    range="5.0"
+    refNode="0>0"
+    type="OUTDOOR"
+    animName="string"
+    animMinLimit="0.0"
+    animMaxLimit="1.0"
+    foldMinLimit="0.0"
+    foldMaxLimit="1.0"
+    forcedStateValue="float"
+    direction="1"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `input` | string | — | **Required.** Input action name (e.g. `IC_CLICK`). |
+| `range` | float | `5.0` | Maximum distance in metres from `refNode` for the button to be active. |
+| `refNode` | node | rootNode | Reference node used to measure range from the player. |
+| `type` | string | — | **Required.** `INDOOR`, `OUTDOOR`, or `INDOOR_OUTDOOR`. |
+| `animName` | string | — | Restricts button to only be active when the named animation is within `animMinLimit`–`animMaxLimit`. |
+| `animMinLimit` | float | `0.0` | Minimum animation time (0–1) for activity restriction. |
+| `animMaxLimit` | float | `1.0` | Maximum animation time (0–1) for activity restriction. |
+| `foldMinLimit` | float | `0.0` | Minimum fold time for activity restriction. |
+| `foldMaxLimit` | float | `1.0` | Maximum fold time for activity restriction. |
+| `forcedStateValue` | float | — | Forces the controller to this exact state value when pressed, instead of toggling. |
+| `direction` | float | `1` | In analog mode: `1` nudges state toward 1.0, `-1` nudges toward 0.0. |
+
+---
+
+## 6. Actors — What Controls Do
+
+Actors respond to state changes. A controller can have multiple actors — all fire together when the controller changes state.
+
+---
+
+### animation
+
+Plays a vehicle animation when the controller is activated/deactivated. This is the most common actor. Multiple `<animation>` elements can appear on the same controller to drive several animations at once.
+
+```xml
+<animation
+    name="openWindow"
+    speedScale="1.0"
+    initTime="0.0"
+    returnOnRelease="false"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — | **Required.** Name of the animation as defined in `<animations>`. |
+| `speedScale` | float | `1.0` | Playback speed multiplier. Negative values play in reverse. |
+| `initTime` | float | — | Sets the animation to this time (0–1) on initial load before savegame state is applied. |
+| `returnOnRelease` | bool | `false` | When true (requires `requireHolding="true"` on the clickPoint), the animation plays forward while held and automatically reverses back to time `0` when released. Useful for spring-return levers. |
+
+**Notes:**
+- In toggle mode: state `1` → plays forward, state `0` → plays backward at `speedScale`.
+- In analog mode: the animation time is set directly to the controller's state value (0–1).
+- With `requireHolding`: releasing the button mid-animation stops it at the current position. The position is saved and synced to all multiplayer clients.
+- With `returnOnRelease`: releasing always reverses to time 0, regardless of current position. The IC state value is **not** updated on release, so other actors are unaffected.
+
+---
+
+### function
+
+Calls a built-in game function when the controller is activated or deactivated. See the [Function Reference](#10-function-reference) for all available names and their child element requirements.
+
+```xml
+<function name="MOTOR_START_STOPP" />
+
+<function name="ATTACHERJOINTS_LIFT_LOWER">
+    <attacherJoint indices="1 2" />
+</function>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — | **Required.** Function name (case-insensitive). |
+
+Functions never save state. `allowsSaving` is automatically forced to `false` on controllers that use them.
+
+---
+
+### axisMovingTool *(added)*
+
+Drives a `<cylindered>` moving tool by mouse drag. Used with an `axisPoint` action. The tool moves while the mouse moves and stops when the mouse is still or the button is released.
+
+```xml
+<!-- Reference by moving tool index (preferred) -->
+<axisMovingTool movingToolIndex="1" />
+
+<!-- Reference by node -->
+<axisMovingTool node="0>4|0" />
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `movingToolIndex` | int | — | 1-based index of the moving tool in the vehicle's `<cylindered><movingTools>` list. Preferred method. |
+| `node` | node | — | Alternative: the i3d node of the moving tool. |
+
+Either `movingToolIndex` or `node` is required — not both.
+
+**Requirements:**
+- The vehicle must have the `Cylindered` specialization (`spec_cylindered`).
+- The controller's action must be an `axisPoint`.
+- Add `requiresEngine="true"` on the `axisPoint` if the engine must be running to drag (optional).
+
+**Movement formula** (same as in-vehicle mouse control):
+```
+move = inputValue × invertAxis × armSensitivity × (16.666 / dt) × mouseSpeedFactor
+```
+`armSensitivity` is the game setting from Options → Controls. `mouseSpeedFactor` comes from the moving tool's XML definition.
+
+---
+
+### leverAnimation *(added)*
+
+Drives an animation to visually represent the axis drag direction in real time. Pair it with an `axisMovingTool` on the same controller. Both actors receive the same mouse speed signal each frame via `setDriveSpeed`.
+
+- Dragging **positive** (mouse up or right) → animation moves toward `1.0`
+- Dragging **negative** (mouse down or left) → animation moves toward `0.0`
+- Mouse still or hold released → animation returns to `neutralTime` (the lever's resting position)
+
+```xml
+<leverAnimation
+    name="hydraulicLever"
+    neutralTime="0.5"
+    speed="3.0"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — | **Required.** Name of the animation to drive. |
+| `neutralTime` | float | `0.5` | Animation time (0–1) the lever rests at when not being dragged. `0.5` = centre. Adjust if your animation's neutral pose isn't exactly at the midpoint. |
+| `speed` | float | `3.0` | How fast the lever snaps to its target, in full animation lengths per second. `3.0` = reaches target in ~0.33 s. Higher = snappier. |
+
+`leverAnimation` state is never saved (the lever always returns to neutral on load).
+
+**Full controller example:**
+
+```xml
+<interactiveControl posText="Move Ramp" negText="">
+    <axisPoint node="leverClickNode" type="OUTDOOR" iconType="CROSS" size="0.04" sensitivity="0.6" dragAxis="Y" />
+    <axisMovingTool movingToolIndex="1" />
+    <leverAnimation name="hydraulicLever" neutralTime="0.5" speed="3.0" />
+</interactiveControl>
+```
+
+---
+
+### objectChange
+
+Changes a node's visibility, translation, rotation, scale, mass, shader parameters, or rigid body type based on the controller's state. Multiple `<objectChange>` elements can appear on the same controller.
+
+```xml
+<objectChange
+    node="0>3|1"
+    visibilityActive="true"
+    visibilityInactive="false"
+    translationActive="0 0.5 0"
+    translationInactive="0 0 0"
+    rotationActive="0 90 0"
+    rotationInactive="0 0 0"
+    scaleActive="1 1 1"
+    scaleInactive="0 0 0"
+    interpolation="false"
+    interpolationTime="1"
+    massActive="100"
+    massInactive="0"
+    centerOfMassActive="0 0 0"
+    centerOfMassInactive="0 0 0"
+    rigidBodyTypeActive="Dynamic"
+    rigidBodyTypeInactive="Static"
+    compoundChildActive="true"
+    compoundChildInactive="false"
+    parentNodeActive="0>2"
+    parentNodeInactive="0>1"
+    shaderParameter="colorScale"
+    shaderParameterActive="1 0 0 1"
+    shaderParameterInactive="0 0 1 1"
+    sharedShaderParameter="false"
+/>
+```
+
+All `*Active` values apply when the controller state is `1` (activated); `*Inactive` values apply at state `0`. Every attribute pair is optional — only include what you need.
+
+---
+
+### dashboard
+
+Ties a vanilla dashboard element to the IC controller state. Uses the existing `<dashboard>` system with IC-specific `valueType` values.
+
+```xml
+<dashboard
+    node="0>4|0"
+    valueType="ic_state"
+    onICActivate="true"
+    onICDeactivate="true"
+    raiseTime="1.0"
+    activeTime="1.0"
+/>
+```
+
+IC-specific `valueType` options:
+
+| valueType | Description |
+|---|---|
+| `ic_state` | Boolean — true when controller is in positive state. |
+| `ic_stateValue` | Float 0–1 — the raw controller state value. |
+| `ic_action` | Fires on IC activation/deactivation events (use with `raiseTime`, `activeTime`, `onICActivate`, `onICDeactivate`). |
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `raiseTime` | float | `1.0` | Time in seconds to raise/activate the dashboard element. |
+| `activeTime` | float | `1.0` | Time in seconds to hold the dashboard active. |
+| `onICActivate` | bool | `true` | Fire dashboard when IC activates. |
+| `onICDeactivate` | bool | `true` | Fire dashboard when IC deactivates. |
+
+All standard dashboard attributes (`rotAxis`, `minRot`, `maxRot`, `emissiveScale`, etc.) are also valid.
+
+---
+
+### dependingInteractiveControl
+
+Blocks or enables this controller based on the state value of another controller.
+
+```xml
+<dependingInteractiveControl
+    index="2"
+    minLimit="0.0"
+    maxLimit="0.5"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `index` | int | — | **Required.** 1-based index of the controlling IC in the same `<interactiveControls>` block. |
+| `minLimit` | float | `0.0` | This controller is active only when the referenced controller's state is ≥ `minLimit`. |
+| `maxLimit` | float | `1.0` | This controller is active only when the referenced controller's state is ≤ `maxLimit`. |
+
+---
+
+## 7. Shared Sub-Elements
+
+These elements can appear inside any `<interactiveControl>` controller alongside the actors and actions.
+
+---
+
+### dependingMovingTool
+
+Prevents a `<cylindered>` moving tool from being driven while this IC controller is in a specific state. Useful to lock a tool in place. Multiple entries allowed.
+
+```xml
+<dependingMovingTool node="0>4|0" isInactive="true" />
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | The moving tool's node. |
+| `isInactive` | bool | `true` | When true, the tool is blocked while this IC is active/configured. |
+
+---
+
+### dependingMovingPart
+
+Same as `dependingMovingTool` but for `<movingParts>` elements. Multiple entries allowed.
+
+```xml
+<dependingMovingPart node="0>4|1" isInactive="true" />
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | The moving part's node. |
+| `isInactive` | bool | `true` | When true, the part is blocked while this IC is active/configured. |
+
+---
+
+### soundModifier
+
+Adjusts interior sound levels when this IC controller is active. Useful for cab controls that open windows or panels.
+
+```xml
+<soundModifier
+    indoorFactor="0.5"
+    delayedSoundAnimationTime="0.3"
+    name="openWindow"
+/>
+```
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `indoorFactor` | float | — | Indoor sound volume multiplier while this IC is active. `0.5` = half volume. |
+| `delayedSoundAnimationTime` | float | — | Wait until the named animation reaches this time before applying the sound change. |
+| `name` | string | — | Animation name to monitor. Defaults to the first `animation` actor on this controller. |
+
+---
+
+### configurationsRestrictions
+
+Restricts this controller to only be available when a specific shop configuration is selected.
+
+```xml
+<configurationsRestrictions>
+    <restriction name="design" indices="1 3" />
+</configurationsRestrictions>
+```
+
+| Attribute | Type | Description |
+|---|---|---|
+| `name` | string | The configuration category name (e.g. `"design"`, `"baseColor"`). |
+| `indices` | int list | Space-separated configuration indices for which this controller is **blocked** (unavailable). |
+
+---
+
+## 8. Animation Part Blocking
+
+You can block an IC controller from within an animation track, useful for preventing interaction during certain animation phases.
+
+```xml
+<animations>
+    <animation name="foldOut">
+        <part
+            node="..."
+            interactiveControlIndex="2"
+            interactiveControlBlocked="true"
+        />
+    </animation>
+</animations>
+```
+
+| Attribute | Type | Description |
+|---|---|---|
+| `interactiveControlIndex` | int | 1-based index of the IC controller to block. |
+| `interactiveControlBlocked` | bool | `true` to block, `false` to unblock at this animation part. |
+
+---
+
+## 9. Custom Click Icons
+
+Register your own click icons for use with `iconType`.
+
+```xml
+<interactiveControl>
+    <registers>
+        <clickIcon
+            name="WINCH"
+            filename="path/to/winchIcon.i3d"
+            node="iconNode"
+            blinkSpeed="1.0"
+        />
+    </registers>
+</interactiveControl>
+```
+
+| Attribute | Type | Description |
+|---|---|---|
+| `name` | string | Name to reference in `iconType`. Case-insensitive; stored uppercase. |
+| `filename` | string | Path to the i3d file containing the icon mesh. |
+| `node` | string | Node index string within the i3d (e.g. `"0"` for the first node). |
+| `blinkSpeed` | float | Base hover blink speed for this icon. |
+
+---
+
+## 10. Function Reference
+
+Functions are used with the `<function name="...">` actor. Some require a child element.
+
+### No child element required
+
+| Function | Description |
+|---|---|
+| `MOTOR_START_STOPP` | Toggle engine on/off |
+| `LIGHTS_TOGGLE` | Toggle all lights |
+| `LIGHTS_WORKBACK_TOGGLE` | Toggle rear work lights |
+| `LIGHTS_WORKFRONT_TOGGLE` | Toggle front work lights |
+| `LIGHTS_HIGHBEAM_TOGGLE` | Toggle high beams |
+| `LIGHTS_TURNLIGHT_HAZARD_TOGGLE` | Toggle hazard lights |
+| `LIGHTS_TURNLIGHT_LEFT_TOGGLE` | Toggle left indicator |
+| `LIGHTS_TURNLIGHT_RIGHT_TOGGLE` | Toggle right indicator |
+| `LIGHTS_BEACON_TOGGLE` | Toggle beacon/strobe lights |
+| `LIGHTS_PIPE_TOGGLE` | Toggle pipe light |
+| `AUTOMATIC_STEERING_TOGGLE` | Toggle auto-steering |
+| `AUTOMATIC_STEERING_LINES_TOGGLE` | Show/hide auto-steering lines |
+| `CRUISE_CONTROL_TOGGLE` | Toggle cruise control |
+| `DRIVE_DIRECTION_TOGGLE` | Toggle drive direction |
+| `COVER_TOGGLE` | Toggle cover open/closed |
+| `RADIO_TOGGLE` | Toggle radio on/off |
+| `RADIO_CHANNEL_NEXT` | Next radio channel |
+| `RADIO_CHANNEL_PREVIOUS` | Previous radio channel |
+| `RADIO_ITEM_NEXT` | Next item in current radio channel |
+| `RADIO_ITEM_PREVIOUS` | Previous item in current radio channel |
+| `REVERSEDRIVING_TOGGLE` | Toggle reverse driving mode |
+| `TURN_ON_OFF` | Turn implement on/off |
+| `FOLDING_TOGGLE` | Fold/unfold vehicle |
+| `PIPE_FOLDING_TOGGLE` | Fold/unfold pipe |
+| `DISCHARGE_TOGGLE` | Toggle discharge |
+| `CRABSTEERING_TOGGLE` | Cycle crab steering mode |
+| `VARIABLE_WORK_WIDTH_LEFT_INCREASE` | Increase left work width |
+| `VARIABLE_WORK_WIDTH_LEFT_DECREASE` | Decrease left work width |
+| `VARIABLE_WORK_WIDTH_RIGHT_INCREASE` | Increase right work width |
+| `VARIABLE_WORK_WIDTH_RIGHT_DECREASE` | Decrease right work width |
+| `VARIABLE_WORK_WIDTH_TOGGLE` | Toggle work width |
+| `BALER_TOGGLE_SIZE` | Toggle bale size |
+| `BALER_DROP_BALE` | Drop bale from baler |
+| `BALER_TOGGLE_AUTOMATIC_DROP` | Toggle automatic bale drop |
+| `BALEWRAPPER_DROP_BALE` | Drop bale from bale wrapper |
+| `BALEWRAPPER_TOGGLE_AUTOMATIC_DROP` | Toggle automatic bale drop from wrapper |
+
+### Requires `<attacherJoint indices="..."/>`
+
+```xml
+<function name="ATTACHERJOINTS_LIFT_LOWER">
+    <attacherJoint indices="1 2" />
+</function>
+```
+
+`indices` is a space-separated list of 1-based attacher joint indices.
+
+| Function | Description |
+|---|---|
+| `ATTACHERJOINTS_LIFT_LOWER` | Lift/lower implement on specified joints |
+| `ATTACHERJOINTS_TURN_ON_OFF` | Turn on/off implement on specified joints |
+| `ATTACHERJOINTS_FOLDING_TOGGLE` | Fold/unfold implement on specified joints |
+| `ATTACHERJOINTS_DISCHARGE_TOGGLE` | Toggle discharge on specified joints |
+| `ATTACHERJOINTS_ATTACH_DETACH` | Attach or detach implement on specified joints |
+| `ATTACHERJOINTS_VARIABLE_WORK_WIDTH_LEFT_INCREASE` | Increase left work width on specified joints |
+| `ATTACHERJOINTS_VARIABLE_WORK_WIDTH_LEFT_DECREASE` | Decrease left work width on specified joints |
+| `ATTACHERJOINTS_VARIABLE_WORK_WIDTH_RIGHT_INCREASE` | Increase right work width on specified joints |
+| `ATTACHERJOINTS_VARIABLE_WORK_WIDTH_RIGHT_DECREASE` | Decrease right work width on specified joints |
+| `ATTACHERJOINTS_VARIABLE_WORK_WIDTH_TOGGLE` | Toggle work width on specified joints |
+
+### Winch functions *(added)* — Requires `<winch ropeIndices="..."/>`
+
+```xml
+<function name="WINCH_IN">
+    <winch ropeIndices="1" />
+</function>
+```
+
+`ropeIndices` is a space-separated list of 1-based rope indices from the vehicle's `<winch>` definition.
+
+| Function | Description | Note |
+|---|---|---|
+| `WINCH_IN` | Pulls rope(s) in while the click point is held | Holding is implicit — no `requireHolding` needed on the `clickPoint` |
+| `WINCH_OUT` | Releases rope(s) while the click point is held | Holding is implicit — no `requireHolding` needed on the `clickPoint` |
+
+**Notes:**
+- The vehicle must have the `Winch` specialization (`spec_winch`).
+- Both functions are hold-to-activate — the winch stops as soon as you release the button.
+- `allowsSaving` is automatically `false`; do not add `allowsSaving="true"`.
+
+### LIGHT_TOGGLE *(added)* — IC-exclusive individual light control
+
+Toggles one or more individual lights exclusively via IC. The nodes must **not** be defined anywhere in `<vehicle.lights>` — IC owns them completely. If you want a light controllable by the F-key system, define it only in `<vehicle.lights>` and use the existing `LIGHTS_*` functions instead.
+
+```xml
+<function name="LIGHT_TOGGLE">
+    <realLight node="0>5|1" />
+    <staticLightMesh node="0>5|2" intensity="10" />
+</function>
+```
+
+Both child elements are optional (you can have just a `realLight`, just a `staticLightMesh`, or both), but at least one must be present. Multiple entries of each type are supported.
+
+**`<realLight>`** — a LIGHT_SOURCE node controlled via `setVisibility`. Do **not** list this node in `<vehicle.lights.realLights>`.
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | **Required.** The LIGHT_SOURCE node to show/hide. |
+
+**`<staticLightMesh>`** — an emissive mesh using the `staticLight` shader variation, controlled via `lightIds0–3` shader parameters. Do **not** list this node in `<staticLightCompounds>`.
+
+| Attribute | Type | Default | Description |
+|---|---|---|---|
+| `node` | node | — | **Required.** The mesh node. Must use the `staticLight` custom shader variation (has the `lightIds0` parameter). |
+| `intensity` | float | `10` | Emissive intensity when on. Use the same value you would put on a `<staticLightCompound><node intensity="">`. |
+
+Because neither node is registered in the game's light system, the game never writes to their visibility or shader parameters. IC's state persists through F-key cycling, vehicle entry, turn signals, and anything else.
+
+---
+
+## 11. Full Example — Winch Controls
+
+```xml
+<interactiveControl>
+    <interactiveControlConfigurations title="$l10n_actionIC_winch">
+        <interactiveControlConfiguration>
+            <interactiveControls>
+                <!-- Outdoor trigger covering the winch area -->
+                <outdoorTrigger
+                    linkNode="0>9|0"
+                    filename="SHARED_INTERACTIVE_TRIGGER"
+                    width="4"
+                    height="3"
+                    length="4"
+                />
+
+                <!-- Pull rope in (requireHolding is implicit for WINCH_IN/WINCH_OUT) -->
+                <interactiveControl posText="Winch In" negText="">
+                    <clickPoint
+                        node="0>9|1"
+                        alignToCamera="true"
+                        type="OUTDOOR"
+                        iconType="CROSS"
+                        size="0.04"
+                    />
+                    <function name="WINCH_IN">
+                        <winch ropeIndices="1" />
+                    </function>
+                </interactiveControl>
+
+                <!-- Release rope out -->
+                <interactiveControl posText="Winch Out" negText="">
+                    <clickPoint
+                        node="0>9|2"
+                        alignToCamera="true"
+                        type="OUTDOOR"
+                        iconType="CROSS"
+                        size="0.04"
+                    />
+                    <function name="WINCH_OUT">
+                        <winch ropeIndices="1" />
+                    </function>
+                </interactiveControl>
+            </interactiveControls>
+        </interactiveControlConfiguration>
+    </interactiveControlConfigurations>
+</interactiveControl>
+```
+
+---
+
+## 12. Full Example — Animation with Function
+
+A cab window that toggles open/closed with an indoor click point, mutes interior sound when open, and also turns on the front work lights.
+
+```xml
+<interactiveControl>
+    <interactiveControls>
+        <interactiveControl posText="Open Window" negText="Close Window" allowsSaving="true">
+            <clickPoint
+                node="windowClickNode"
+                type="INDOOR"
+                iconType="CROSS"
+                size="0.035"
+                alignToCamera="true"
+            />
+            <animation name="openWindow" speedScale="1.0" />
+            <function name="LIGHTS_WORKFRONT_TOGGLE" />
+            <soundModifier indoorFactor="0.4" delayedSoundAnimationTime="0.6" name="openWindow" />
+        </interactiveControl>
+    </interactiveControls>
+</interactiveControl>
+```
+
+---
+
+## 13. Full Example — Axis Drag Moving Tool
+
+A trailer ramp driven up/down by mouse drag while the button is held. Uses `axisPoint` + `axisMovingTool` + `leverAnimation` for a visual lever indicator.
+
+```xml
+<interactiveControl>
+    <interactiveControlConfigurations title="$l10n_actionIC_ramp">
+        <interactiveControlConfiguration>
+            <interactiveControls>
+                <outdoorTrigger
+                    linkNode="rampTriggerLink"
+                    filename="SHARED_INTERACTIVE_TRIGGER"
+                    width="3"
+                    height="2"
+                    length="5"
+                />
+
+                <interactiveControl posText="Move Ramp" negText="">
+                    <axisPoint
+                        node="rampClickNode"
+                        type="OUTDOOR"
+                        iconType="CROSS"
+                        size="0.04"
+                        alignToCamera="true"
+                        sensitivity="0.6"
+                        dragAxis="Y"
+                    />
+                    <axisMovingTool movingToolIndex="1" />
+                    <leverAnimation name="hydraulicLever" neutralTime="0.5" speed="3.0" />
+                </interactiveControl>
+            </interactiveControls>
+        </interactiveControlConfiguration>
+    </interactiveControlConfigurations>
+</interactiveControl>
+```
+
+---
+
+## 14. Saving Behaviour
+
+| Actor type | Saves state? | Notes |
+|---|---|---|
+| `animation` | Yes (default) | State value (0–1) is saved and restored on load. |
+| `objectChange` | Yes (default) | Inherits controller save state. |
+| `function` | **Never** | Functions have no persistent state. `allowsSaving` forced to `false`. |
+| `axisMovingTool` | **Never** | Moving tool position is managed by `Cylindered`, not IC. `allowsSaving` forced to `false`. |
+| `leverAnimation` | **Never** | Lever always returns to `neutralTime` on load. No state to save. |
+| `dashboard` | No | Dashboard state is cosmetic only. |
+| `dependingInteractiveControl` | No | Blocking state is derived at runtime from the referenced controller. |
+
+If you see the log warning `"Loaded interactive control does not allow saving ... skipping this control"`, it means a previously saved savegame had stored state for a controller that now uses a function or axisMovingTool actor. This is harmless — the saved state is ignored and will not be written back on the next save.

--- a/i18n/locale_br.xml
+++ b/i18n/locale_br.xml
@@ -47,8 +47,8 @@
         <e k="actionIC_pipeLightsOn" v="IC: Acenda a luz do tubo"/>
         <e k="actionIC_pumpDirectionDrain" v="IC: Mudar a direção da bomba para: Drenagem"/>
         <e k="actionIC_pumpDirectionFill" v="IC: Mudar a direção da bomba para: Encher"/>
-        <e k="actionIC_radioOff" v="IC: Radio off"/>
-        <e k="actionIC_radioOn" v="IC: Radio on"/>
+        <e k="actionIC_radioOff" v="IC: Rádio desligado"/>
+        <e k="actionIC_radioOn" v="IC: Rádio ligado"/>
         <e k="actionIC_reverseDriving_toggle" v="IC: Alternar a marcha-atrás"/>
         <e k="actionIC_sa_activate" v="IC: Ativar orientação de pista"/>
         <e k="actionIC_sa_deactivate" v="IC: Desativar a orientação de pista"/>

--- a/i18n/locale_de.xml
+++ b/i18n/locale_de.xml
@@ -75,7 +75,7 @@
         <e k="action_activateIC" v="Interactive Control aktivieren"/>
         <e k="action_deactivateIC" v="Interactive Control deaktivieren"/>
         <e k="configuration_interactiveControl" v="Interactive Control"/>
-        <e k="input_IC_CLICK" v="IC: Interactive Control ClickPoint"/>
+        <e k="input_IC_CLICK" v="IC: Interactive Control Klickpunkt"/>
         <e k="input_IC_TOGGLE_STATE" v="IC: Interactive Control umschalten"/>
         <e k="settingsIC_clickPointHover_optionTime" v="%.1f s"/>
         <e k="settingsIC_clickPointHover_optionTimeOff" v="Aus"/>

--- a/i18n/locale_fr.xml
+++ b/i18n/locale_fr.xml
@@ -83,7 +83,7 @@
         <e k="settingsIC_clickPointHover_tooltip" v="Changement d&#39;InteractiveControl si vous survolez le clickPoint pendant un certain temps"/>
         <e k="settingsIC_keepAlive_title" v="Garder IC activé"/>
         <e k="settingsIC_keepAlive_tooltip" v="InteractiveControl reste actif lorsque vous quittez le véhicule."/>
-        <e k="settingsIC_state_option01" v="Switchable"/>
+        <e k="settingsIC_state_option01" v="Commutable"/>
         <e k="settingsIC_state_option02" v="Toujours actif"/>
         <e k="settingsIC_state_option03" v="Désactivé"/>
         <e k="settingsIC_state_title" v="État IC"/>

--- a/i18n/locale_it.xml
+++ b/i18n/locale_it.xml
@@ -47,8 +47,8 @@
         <e k="actionIC_pipeLightsOn" v="IC: Accendere la luce del tubo"/>
         <e k="actionIC_pumpDirectionDrain" v="IC: Cambiare la direzione della pompa in: Vuoto"/>
         <e k="actionIC_pumpDirectionFill" v="IC: Cambiare la direzione della pompa in: Riempimento"/>
-        <e k="actionIC_radioOff" v="IC: Radio off"/>
-        <e k="actionIC_radioOn" v="IC: Radio on"/>
+        <e k="actionIC_radioOff" v="IC: Radio spenta"/>
+        <e k="actionIC_radioOn" v="IC: Radio accesa"/>
         <e k="actionIC_reverseDriving_toggle" v="IC: Cambiare la direzione di marcia"/>
         <e k="actionIC_sa_activate" v="IC: Attivare la guida di corsia"/>
         <e k="actionIC_sa_deactivate" v="IC: Disattivare la guida di corsia"/>

--- a/i18n/locale_pl.xml
+++ b/i18n/locale_pl.xml
@@ -47,8 +47,8 @@
         <e k="actionIC_pipeLightsOn" v="IC: Włączanie światła rury"/>
         <e k="actionIC_pumpDirectionDrain" v="IC: Zmiana kierunku pompy na: Puste"/>
         <e k="actionIC_pumpDirectionFill" v="IC: Zmień kierunek pompy na: Napełnianie"/>
-        <e k="actionIC_radioOff" v="IC: Radio off"/>
-        <e k="actionIC_radioOn" v="IC: Radio on"/>
+        <e k="actionIC_radioOff" v="IC: Radio wyłączone"/>
+        <e k="actionIC_radioOn" v="IC: Radio włączone"/>
         <e k="actionIC_reverseDriving_toggle" v="IC: Zmiana kierunku jazdy"/>
         <e k="actionIC_sa_activate" v="IC: Aktywacja naprowadzania na pas ruchu"/>
         <e k="actionIC_sa_deactivate" v="IC: Wyłącz naprowadzanie na pas ruchu"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="107" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://validation.gdn.giants-software.com/xml/fs25/modDesc.xsd">
     <author>Vertex Dezign</author>
-    <version>1.2.0.2</version>
+    <version>1.3.0.0</version>
 
     <title>
         <en>Interactive Control</en>
@@ -21,6 +21,16 @@ Using the controls you can steer different things:
 A few vehicles are already equipped with IC
 
 For further informations: <a href="https://github.com/TobiasF92/FS25_interactiveControl/blob/master/README.md">README</a> on Github.
+
+Changelog (1.3.0.0):
+- Added axis-drag moving tool system (axisPoint action, axisMovingTool actor, leverAnimation actor)
+- Added WINCH_IN / WINCH_OUT hold-to-activate winch functions
+- Added LIGHT_TOGGLE function for IC-exclusive individual light control
+- Fixed InteractiveClickPoint scale corruption bug
+- Fixed axis moving tool on dedicated servers
+- Fixed untranslated radio on/off strings in BR, IT, PL locales
+- Fixed untranslated settingsIC_state_option01 in FR locale
+- Re-enabled InteractiveActorDashboard
 
 Changelog (1.2.0.2):
 - Added translation for Espanol

--- a/src/events/ICMovingToolInputEvent.lua
+++ b/src/events/ICMovingToolInputEvent.lua
@@ -1,0 +1,51 @@
+---@class ICMovingToolInputEvent : Event
+ICMovingToolInputEvent = {}
+
+local icMovingToolInputEvent_mt = Class(ICMovingToolInputEvent, Event)
+
+InitEventClass(ICMovingToolInputEvent, "ICMovingToolInputEvent")
+
+function ICMovingToolInputEvent.emptyNew()
+    local self = Event.new(icMovingToolInputEvent_mt)
+    return self
+end
+
+---@param object table Vehicle object
+---@param toolIndex integer 1-based index into spec_cylindered.movingTools
+---@param moveValue number Move value in Cylindered's internal units (same range as tool.move)
+function ICMovingToolInputEvent.new(object, toolIndex, moveValue)
+    local self = ICMovingToolInputEvent.emptyNew()
+    self.object = object
+    self.toolIndex = toolIndex
+    self.moveValue = moveValue
+    return self
+end
+
+function ICMovingToolInputEvent:readStream(streamId, connection)
+    self.object = NetworkUtil.readNodeObject(streamId)
+    self.toolIndex = streamReadUInt8(streamId)
+    -- Decode using the same 12-bit quantization Cylindered uses for input values (range -5..5)
+    self.moveValue = (streamReadUIntN(streamId, 12) / 4095 * 2 - 1) * 5
+    if math.abs(self.moveValue) < 0.01 then
+        self.moveValue = 0
+    end
+    self:run(connection)
+end
+
+function ICMovingToolInputEvent:writeStream(streamId, connection)
+    NetworkUtil.writeNodeObject(streamId, self.object)
+    streamWriteUInt8(streamId, self.toolIndex)
+    local quantized = math.floor((math.clamp(self.moveValue / 5, -1, 1) + 1) / 2 * 4095)
+    streamWriteUIntN(streamId, quantized, 12)
+end
+
+function ICMovingToolInputEvent:run(connection)
+    -- Client -> server only; the server's Cylindered:onUpdate() handles position sync back.
+    if self.object ~= nil and self.object.spec_cylindered ~= nil then
+        local tool = self.object.spec_cylindered.movingTools[self.toolIndex]
+        if tool ~= nil then
+            tool.move = self.moveValue
+            tool.lastInputTime = g_time
+        end
+    end
+end

--- a/src/interactiveControl/InteractiveController.lua
+++ b/src/interactiveControl/InteractiveController.lua
@@ -136,6 +136,9 @@ function InteractiveController.new(modName, modDirectory, customMt)
     self.externallyBlocked = false
     self.hoverTimeOut = 0
     self.lastChangeTime = 0
+    self.holdResumeState = nil
+    self.isHoldActive = false
+    self._holdTargetState = nil
 
     self.interactiveActors = {}
     self.interactiveActions = {}
@@ -522,10 +525,126 @@ end
 
 ---Executes controller, based on analog or not
 function InteractiveController:execute()
+    if self.activeAction ~= nil and self.activeAction.canExecute ~= nil and not self.activeAction:canExecute() then
+        return
+    end
+
     if self:isAnalog() then
         self:changeAnalogStateValueInDirection(self:getActiveActionDirection())
+    elseif self.holdResumeState ~= nil then
+        -- Resume toward the same end we were playing to before the hold was released.
+        -- Normalize to binary in case of any corruption (holdResumeState must be 0 or 1).
+        local resumeState = self.holdResumeState
+        if resumeState > 0 and resumeState < 1 then
+            resumeState = (not self:getStateBool()) and 1.0 or 0.0
+        end
+        self.holdResumeState = nil
+        if self:anyActionRequiresHolding() then
+            self.isHoldActive = true
+            self._holdTargetState = resumeState
+        end
+        self:setStateValue(resumeState)
     else
         self:toggleStateValue()
+        if self:anyActionRequiresHolding() then
+            self.isHoldActive = true
+            self._holdTargetState = self.stateValue  -- after toggle: exactly 0.0 or 1.0
+        end
+    end
+end
+
+---Returns true if the currently active action requires holding
+---@return boolean requiresHolding
+function InteractiveController:requiresHolding()
+    if self.activeAction ~= nil and self.activeAction.requiresHolding ~= nil then
+        return self.activeAction:requiresHolding()
+    end
+    return false
+end
+
+---Returns true if ANY action or actor in this controller requires holding
+---@return boolean anyRequiresHolding
+function InteractiveController:anyActionRequiresHolding()
+    for _, action in ipairs(self.interactiveActions) do
+        if action.requiresHolding ~= nil and action:requiresHolding() then
+            return true
+        end
+    end
+    for _, actor in ipairs(self.interactiveActors) do
+        if actor.requiresHolding ~= nil and actor:requiresHolding() then
+            return true
+        end
+    end
+    return false
+end
+
+---Returns true if all actors allow a hold to start right now (e.g. engine is running)
+---@return boolean canStart
+function InteractiveController:canStartAxisHold()
+    for _, actor in ipairs(self.interactiveActors) do
+        if actor.canStartHold ~= nil and not actor:canStartHold() then
+            return false
+        end
+    end
+    return true
+end
+
+---Returns true if ANY action in this controller is an axis drag action
+---@return boolean anyIsAxis
+function InteractiveController:anyActionIsAxis()
+    for _, action in ipairs(self.interactiveActions) do
+        if action.isAxisAction ~= nil and action:isAxisAction() then
+            return true
+        end
+    end
+    return false
+end
+
+---Returns the sensitivity of the first axis action found in this controller
+---@return number sensitivity
+function InteractiveController:getAxisSensitivity()
+    for _, action in ipairs(self.interactiveActions) do
+        if action.getAxisSensitivity ~= nil then
+            return action:getAxisSensitivity()
+        end
+    end
+    return 5.0
+end
+
+---Returns the drag axis ("X" or "Y") of the first axis action found in this controller
+---@return string dragAxis
+function InteractiveController:getAxisDragAxis()
+    for _, action in ipairs(self.interactiveActions) do
+        if action.getDragAxis ~= nil then
+            return action:getDragAxis()
+        end
+    end
+    return "Y"
+end
+
+---Sets drive speed on all moving tool actors in this controller
+---@param speed number Drive speed to apply
+function InteractiveController:setAxisDriveSpeed(speed)
+    for _, actor in ipairs(self.interactiveActors) do
+        if actor.setDriveSpeed ~= nil then
+            actor:setDriveSpeed(speed)
+        end
+    end
+end
+
+---Called when a held button is released; delegates to actors to stop and sync animation position
+function InteractiveController:onHoldReleased()
+    self.isHoldActive = false
+    -- Read the explicit binary target we stored in execute(), not stateValue which may be mid-float.
+    local targetState = self._holdTargetState or (self:getStateBool() and 1.0 or 0.0)
+    self._holdTargetState = nil
+    self:callInteractiveBaseFunction('onHoldReleased', true, false)
+    -- After actors run, stateValue is the mid-float stop position.
+    -- Store the original binary target so the next press resumes in the same direction.
+    if self.stateValue > 0 and self.stateValue < 1 then
+        self.holdResumeState = targetState
+    else
+        self.holdResumeState = nil
     end
 end
 
@@ -599,13 +718,30 @@ function InteractiveController:updateActiveAction()
 
     for _, action in ipairs(self.interactiveActions) do
         if action:isExecutable() then
-            --Todo: add priority?
             self.activeAction = action
             break
         end
     end
 
     return self.activeAction
+end
+
+---Returns the minimum squared screen-space distance to cursor across all executable actions.
+---Actions without getMouseDistSq (e.g. buttons) return math.huge.
+---@return number distSq
+function InteractiveController:getActiveActionDistSq()
+    local minDistSq = math.huge
+
+    for _, action in ipairs(self.interactiveActions) do
+        if action:isExecutable() and action.getMouseDistSq ~= nil then
+            local d = action:getMouseDistSq()
+            if d < minDistSq then
+                minDistSq = d
+            end
+        end
+    end
+
+    return minDistSq
 end
 
 ---Returns direction of active action
@@ -619,7 +755,7 @@ function InteractiveController:getActiveActionDirection()
 end
 
 ---Returns action text by controller state
----@param getForced? boolean
+---@param getForced boolean
 ---@return string actionText
 function InteractiveController:getActionText(getForced)
     if getForced == nil or getForced then
@@ -638,21 +774,33 @@ function InteractiveController:getActionText(getForced)
         return self:getActiveActionDirection() >= 0 and self.posText or self.negText
     end
 
+    if self:anyActionRequiresHolding() then
+        if self.isHoldActive then
+            -- During active hold: show the direction currently playing (opposite of target state).
+            -- stateValue is already the target (0 or 1), so invert getStateBool to get current direction.
+            return (not self:getStateBool()) and self.posText or self.negText
+        elseif self.holdResumeState ~= nil then
+            -- After mid-stop: show what the next hold will do (resume toward holdResumeState).
+            -- holdResumeState=0 means resuming toward 0 → posText; =1 means toward 1 → negText.
+            return (self.holdResumeState < 0.5) and self.posText or self.negText
+        end
+    end
+
     return self:getStateBool() and self.posText or self.negText
 end
 
 ---Returns action input button by controller state
 ---@return InputAction inputButton
 function InteractiveController:getActionInputButton()
-    return self.activeAction.inputButton
+    return self.activeAction ~= nil and self.activeAction.inputButton or nil
 end
 
 ------------------------------------------------------ Cylindered ------------------------------------------------------
 
----Returns table with all depending moving tools
----@return table
-function InteractiveController:getMovingTools()
-    return self.movingToolsInactive
+---Returns true if moving tools are set, false otherwise
+---@return boolean hasDependingMovingTools
+function InteractiveController:hasDependingMovingTools()
+    return table.size(self.movingToolsInactive) > 0
 end
 
 ---Returns true if movingTool is inactive, false otherwise
@@ -666,10 +814,10 @@ function InteractiveController:getMovingToolIsInactive(movingTool)
     return false
 end
 
----Returns table with all depending moving parts
----@return table
-function InteractiveController:getMovingParts()
-    return self.movingPartsInactive
+---Returns true if moving parts are set, false otherwise
+---@return boolean hasDependingMovingParts
+function InteractiveController:hasDependingMovingParts()
+    return table.size(self.movingPartsInactive) > 0
 end
 
 ---Returns true if movingPart is inactive, false otherwise

--- a/src/interactiveControl/interactiveActions/InteractiveAxisPoint.lua
+++ b/src/interactiveControl/interactiveActions/InteractiveAxisPoint.lua
@@ -1,0 +1,93 @@
+------------------------------------------------------------------------------------------------------------------------
+-- InteractiveAxisPoint
+------------------------------------------------------------------------------------------------------------------------
+-- Purpose: Interactive action class for axis drag control — mouse hold + drag drives a moving tool.
+--
+---@author John Deere 6930 @VertexDezign
+------------------------------------------------------------------------------------------------------------------------
+
+---@class InteractiveAxisPoint: InteractiveClickPoint
+InteractiveAxisPoint = {}
+
+local interactiveAxisPoint_mt = Class(InteractiveAxisPoint, InteractiveClickPoint)
+
+-- Vehicle-only; shares the same visual click-point infrastructure
+InteractiveAxisPoint.INPUT_TYPES = { InteractiveController.INPUT_TYPES.VEHICLE }
+InteractiveAxisPoint.KEY_NAME = "axisPoint"
+
+---Register AXIS_POINT interactive action
+InteractiveAction.registerInteractiveAction("AXIS_POINT", InteractiveAxisPoint)
+
+---Register XMLPaths to XMLSchema
+---@param schema XMLSchema Instance of XMLSchema to register path to
+---@param basePath string Base path for path registrations
+---@param controllerPath string Controller path for path registrations
+function InteractiveAxisPoint.registerXMLPaths(schema, basePath, controllerPath)
+    InteractiveAxisPoint:superClass().registerXMLPaths(schema, basePath, controllerPath)
+
+    schema:register(XMLValueType.FLOAT, basePath .. "#sensitivity", "Speed multiplier relative to in-vehicle mouse control (1.0 = identical feel, 2.0 = twice as fast)", 1.0)
+    schema:register(XMLValueType.STRING, basePath .. "#dragAxis", "Mouse axis used to drive the tool: Y (up/down, default) or X (left/right)", "Y")
+end
+
+---Creates new instance of InteractiveAxisPoint
+---@param modName string mod name
+---@param modDirectory string mod directory
+---@param customMt? metatable custom metatable
+---@return InteractiveAxisPoint
+function InteractiveAxisPoint.new(modName, modDirectory, customMt)
+    local self = InteractiveAxisPoint:superClass().new(modName, modDirectory, customMt or interactiveAxisPoint_mt)
+
+    self.sensitivity = 1.0
+    self.dragAxis = "Y"
+    -- Set the field so InteractiveClickPoint's hover auto-execute check skips this action type.
+    self.requireHolding = true
+
+    return self
+end
+
+---Loads InteractiveAxisPoint data from xmlFile
+---@param xmlFile XMLFile Instance of XMLFile
+---@param key string XML key to load from
+---@param target any Target vehicle
+---@param interactiveController InteractiveController Instance of InteractiveController
+---@return boolean loaded
+function InteractiveAxisPoint:loadFromXML(xmlFile, key, target, interactiveController)
+    if not InteractiveAxisPoint:superClass().loadFromXML(self, xmlFile, key, target, interactiveController) then
+        return false
+    end
+
+    self.sensitivity = xmlFile:getValue(key .. "#sensitivity", 1.0)
+
+    local dragAxis = xmlFile:getValue(key .. "#dragAxis", "Y"):upper()
+    if dragAxis ~= "X" and dragAxis ~= "Y" then
+        Logging.xmlWarning(xmlFile, "axisPoint: invalid dragAxis '%s', expected X or Y — defaulting to Y", dragAxis)
+        dragAxis = "Y"
+    end
+    self.dragAxis = dragAxis
+
+    return true
+end
+
+---Returns true — axis points always require the button to be held
+---@return boolean requireHolding
+function InteractiveAxisPoint:requiresHolding()
+    return true
+end
+
+---Returns true — identifies this action as an axis drag action (not a simple click)
+---@return boolean isAxis
+function InteractiveAxisPoint:isAxisAction()
+    return true
+end
+
+---Returns the drag sensitivity for this axis point
+---@return number sensitivity
+function InteractiveAxisPoint:getAxisSensitivity()
+    return self.sensitivity
+end
+
+---Returns the mouse axis used to drive this axis point ("X" or "Y")
+---@return string dragAxis
+function InteractiveAxisPoint:getDragAxis()
+    return self.dragAxis
+end

--- a/src/interactiveControl/interactiveActions/InteractiveClickPoint.lua
+++ b/src/interactiveControl/interactiveActions/InteractiveClickPoint.lua
@@ -41,11 +41,14 @@ function InteractiveClickPoint.registerXMLPaths(schema, basePath, controllerPath
         iconTypes = string.format("%s %s", iconTypes, name)
     end
 
-    schema:register(XMLValueType.STRING, basePath .. "#iconType", ("Types of click point: %s"):format(iconTypes), "CROSS")
+    schema:register(XMLValueType.STRING, basePath .. "#iconType", ("Types of click point: %s"):format(iconTypes), "CROSS", true)
     schema:register(XMLValueType.BOOL, basePath .. "#alignToCamera", "Aligns click point to current camera", true)
     schema:register(XMLValueType.BOOL, basePath .. "#invertX", "Invert click icon on x-axis", false)
     schema:register(XMLValueType.BOOL, basePath .. "#invertZ", "Invert click icon on z-axis", false)
-    schema:register(XMLValueType.BOOL, basePath .. "#showClickIcon", "Show click icon if activated, if false the click point is still useable.", true)
+    schema:register(XMLValueType.BOOL, basePath .. "#requireHolding", "Requires mouse button held; releases stop the animation at current position", false)
+    schema:register(XMLValueType.BOOL, basePath .. "#requiresEngine", "When true, the click icon is hidden and inactive unless the vehicle engine is running", false)
+    schema:register(XMLValueType.VECTOR_3, basePath .. "#color", "RGB color multiplier for the click icon (e.g. '1 0 0' for red, '1 1 1' for white)", false)
+    schema:register(XMLValueType.FLOAT, basePath .. "#intensity", "Emissive intensity (lightControl) of the click icon — higher values make colors more vivid and dark colors darker (0-20)", 1.0)
 end
 
 ---Create new instance of InteractiveClickPoint
@@ -67,9 +70,13 @@ function InteractiveClickPoint.new(modName, modDirectory, customMt)
     self.alignToCamera = true
     self.invertX = false
     self.invertZ = false
+    self.requireHolding = false
+    self.requiresEngine = false
+    self.color = nil
+    self.intensity = 1.0
     self.sharedLoadRequestId = nil
     self.hoverTime = 0
-    self.showClickIcon = true
+    self.mouseDistSq = math.huge
 
     return self
 end
@@ -115,9 +122,12 @@ function InteractiveClickPoint:loadFromXML(xmlFile, key, target, interactiveCont
     self.alignToCamera = xmlFile:getValue(key .. "#alignToCamera", true)
     self.invertX = xmlFile:getValue(key .. "#invertX", false)
     self.invertZ = xmlFile:getValue(key .. "#invertZ", false)
+    self.requireHolding = xmlFile:getValue(key .. "#requireHolding", false)
+    self.requiresEngine = xmlFile:getValue(key .. "#requiresEngine", false)
+    self.color = xmlFile:getValue(key .. "#color", nil, true)
+    self.intensity = xmlFile:getValue(key .. "#intensity", 1.0)
     self.rotation = xmlFile:getValue(key .. "#rotation", nil, true)
     self.translation = xmlFile:getValue(key .. "#translation", nil, true)
-    self.showClickIcon = xmlFile:getValue(key .. "#showClickIcon", true)
     self.sharedLoadRequestId = self:loadIconType(iconType, target)
 
     return true
@@ -152,7 +162,7 @@ function InteractiveClickPoint:update(isIndoor, isOutdoor, hasInput)
         return
     end
 
-    if self:isExecutable() and not self.interactiveController:hasHoverTimeout() then
+    if self:isExecutable() and not self.interactiveController:hasHoverTimeout() and not self.requireHolding then
         if self.hoverTime == 0 then
             self.hoverTime = g_currentMission.time + clickPointHoverTime * 1000
         else
@@ -180,6 +190,20 @@ function InteractiveClickPoint:isActivatable()
     return InteractiveClickPoint:superClass().isActivatable(self)
 end
 
+---Returns false (with a warning popup) if requiresEngine is set and the engine is not running.
+---Called by the controller before executing so the icon remains visible and hoverable.
+---@return boolean canExecute
+function InteractiveClickPoint:canExecute()
+    if self.requiresEngine then
+        local rootVehicle = self.target.rootVehicle
+        if rootVehicle ~= nil and rootVehicle.getIsMotorStarted ~= nil and not rootVehicle:getIsMotorStarted() then
+            g_currentMission:showBlinkingWarning(g_i18n:getText("warning_motorNotStarted"), 2000)
+            return false
+        end
+    end
+    return true
+end
+
 ---Sets activation state
 ---@param activated boolean is action activated
 ---@param forced? boolean Forced activation set
@@ -187,7 +211,7 @@ function InteractiveClickPoint:setActivated(activated, forced)
     InteractiveClickPoint:superClass().setActivated(self, activated, forced)
 
     if self.clickIconNode ~= nil then
-        setVisibility(self.clickIconNode, self.activated and self.showClickIcon)
+        setVisibility(self.clickIconNode, self.activated)
     end
 
     if not self.activated then
@@ -196,8 +220,8 @@ function InteractiveClickPoint:setActivated(activated, forced)
 end
 
 ---Updates screen position of clickPoint
----@param mousePosX number|nil x position of mouse
----@param mousePosY number|nil y position of mouse
+---@param mousePosX number x position of mouse
+---@param mousePosY number y position of mouse
 ---@param isIndoor boolean True if update is indoor
 ---@param isOutdoor boolean True if update is outdoor
 function InteractiveClickPoint:updateScreenPosition(mousePosX, mousePosY, isIndoor, isOutdoor)
@@ -208,29 +232,15 @@ function InteractiveClickPoint:updateScreenPosition(mousePosX, mousePosY, isIndo
     self.screenPosY = sy
 
     local isOnScreen = sx > -1 and sx < 2 and sy > -1 and sy < 2 and sz <= 1
-    if not isOnScreen then
-        return
-    end
 
-    local cameraNode = getCamera()
-    if entityExists(cameraNode) then
-        if self.alignToCamera then
-            -- Align clickPoint node to camera
-            local xC, yC, zC = getWorldTranslation(cameraNode)
-            local dirX, dirY, dirZ = xC - x, yC - y, zC - z
+    if isOnScreen then
+        local cameraNode = getCamera()
 
-            if self.invertZ then
-                dirX = -dirX
-                dirY = -dirY
-                dirZ = -dirZ
-            end
-
-            I3DUtil.setWorldDirection(self.node, dirX, dirY, dirZ, 0, 1, 0)
-        else
-            if isOutdoor then
-                -- Disable static clickPoint if not in camera direction view
-                local dirX, dirY, dirZ = localDirectionToWorld(self.node, 0, 0, 1)
-                local cameraDirectionX, cameraDirectionY, cameraDirectionZ = localDirectionToWorld(cameraNode, 0, 0, -1)
+        if entityExists(cameraNode) then
+            if self.alignToCamera then
+                -- Align clickPoint node to camera
+                local xC, yC, zC = getWorldTranslation(cameraNode)
+                local dirX, dirY, dirZ = xC - x, yC - y, zC - z
 
                 if self.invertZ then
                     dirX = -dirX
@@ -238,16 +248,30 @@ function InteractiveClickPoint:updateScreenPosition(mousePosX, mousePosY, isIndo
                     dirZ = -dirZ
                 end
 
-                local dotProduct = MathUtil.dotProduct(cameraDirectionX, cameraDirectionY, cameraDirectionZ, dirX, dirY, dirZ)
-                if dotProduct > InteractiveClickPoint.DOT_PRODUCT_LIMIT then
-                    mousePosX = nil
-                    mousePosY = nil
+                I3DUtil.setWorldDirection(self.node, dirX, dirY, dirZ, 0, 1, 0)
+            else
+                if isOutdoor then
+                    -- Disable static clickPoint if not in camera direction view
+                    local dirX, dirY, dirZ = localDirectionToWorld(self.node, 0, 0, 1)
+                    local cameraDirectionX, cameraDirectionY, cameraDirectionZ = localDirectionToWorld(cameraNode, 0, 0, -1)
+
+                    if self.invertZ then
+                        dirX = -dirX
+                        dirY = -dirY
+                        dirZ = -dirZ
+                    end
+
+                    local dotProduct = MathUtil.dotProduct(cameraDirectionX, cameraDirectionY, cameraDirectionZ, dirX, dirY, dirZ)
+                    if dotProduct > InteractiveClickPoint.DOT_PRODUCT_LIMIT then
+                        mousePosX = nil
+                        mousePosY = nil
+                    end
                 end
             end
         end
-    end
 
-    self:updateClickable(mousePosX, mousePosY)
+        self:updateClickable(mousePosX, mousePosY)
+    end
 end
 
 ---Updates clickable state by mouse position
@@ -259,7 +283,7 @@ function InteractiveClickPoint:updateClickable(mousePosX, mousePosY)
         local isMouseOver = mousePosX > self.screenPosX - halfSize and mousePosX < self.screenPosX + halfSize
             and mousePosY > self.screenPosY - halfSize and mousePosY < self.screenPosY + halfSize
 
-        if self.clickIconNode ~= nil and self.showClickIcon then
+        if self.clickIconNode ~= nil then
             local scale = getScale(self.clickIconNode)
             scale = math.abs(scale)
             if isMouseOver then
@@ -269,7 +293,7 @@ function InteractiveClickPoint:updateClickable(mousePosX, mousePosY)
                 scale = scale + self.blinkSpeed * self.blinkSpeedScale
             else
                 if scale ~= self.size then
-                    self.size = scale
+                    scale = self.size
                 end
             end
 
@@ -277,10 +301,26 @@ function InteractiveClickPoint:updateClickable(mousePosX, mousePosY)
             setScale(self.clickIconNode, scale * xScale, scale, scale)
         end
 
+        if isMouseOver then
+            local dx = mousePosX - self.screenPosX
+            local dy = mousePosY - self.screenPosY
+            self.mouseDistSq = dx * dx + dy * dy
+        else
+            self.mouseDistSq = math.huge
+        end
+
         self:setClickable(isMouseOver)
     else
+        self.mouseDistSq = math.huge
         self:setClickable(false)
     end
+end
+
+---Returns squared screen-space distance from cursor to this click point's center.
+---math.huge when not hovered.
+---@return number mouseDistSq
+function InteractiveClickPoint:getMouseDistSq()
+    return self.mouseDistSq
 end
 
 ---Sets clickable state
@@ -301,6 +341,12 @@ end
 ---@return boolean executable is executable
 function InteractiveClickPoint:isExecutable()
     return InteractiveClickPoint:superClass().isExecutable(self) and self:isClickable()
+end
+
+---Returns true if this click point requires the button to be held during animation
+---@return boolean requireHolding
+function InteractiveClickPoint:requiresHolding()
+    return self.requireHolding
 end
 
 ---Returns max hover timeout
@@ -360,11 +406,17 @@ function InteractiveClickPoint:onIconTypeLoading(i3dNode, failedReason, args)
     setRotation(node, 0, yRot, 0)
     local xScale = self.invertX and -1 or 1
     setScale(node, self.size * xScale, self.size, self.size)
-    -- setVisibility(node, true)
     setVisibility(node, false)
 
     self.clickIconNode = node
     self.blinkSpeed = clickIcon.blinkSpeed
+
+    local r, g, b = 0.518, 0.667, 0.063  -- default: RGB 132 170 16
+    if self.color ~= nil then
+        r, g, b = self.color[1], self.color[2], self.color[3]
+    end
+    setShaderParameter(node, "colorScale", r, g, b, 0, false)
+    setShaderParameter(node, "lightControl", self.intensity, 0, 0, 0, false)
 
     link(self.node, node)
     delete(i3dNode)

--- a/src/interactiveControl/interactiveActors/InteractiveActorLeverAnimation.lua
+++ b/src/interactiveControl/interactiveActors/InteractiveActorLeverAnimation.lua
@@ -1,0 +1,109 @@
+------------------------------------------------------------------------------------------------------------------------
+-- InteractiveActorLeverAnimation
+------------------------------------------------------------------------------------------------------------------------
+-- Purpose: Drives an animation to visually reflect the current axis drag direction.
+--          While dragging positive (e.g. mouse up / right), the animation moves toward 1.0.
+--          While dragging negative, it moves toward 0.0.
+--          When the drag stops or the hold is released, the animation returns to neutralTime (default 0.5).
+--
+---@author John Deere 6930 @VertexDezign
+------------------------------------------------------------------------------------------------------------------------
+
+---@class InteractiveActorLeverAnimation: InteractiveActor
+InteractiveActorLeverAnimation = {}
+
+local interactiveActorLeverAnimation_mt = Class(InteractiveActorLeverAnimation, InteractiveActor)
+
+InteractiveActorLeverAnimation.INPUT_TYPES = { InteractiveController.INPUT_TYPES.VEHICLE }
+InteractiveActorLeverAnimation.KEY_NAME = "leverAnimation"
+
+---Register LEVER_ANIMATION interactive actor
+InteractiveActor.registerInteractiveActor("LEVER_ANIMATION", InteractiveActorLeverAnimation)
+
+---Register XMLPaths to XMLSchema
+---@param schema XMLSchema Instance of XMLSchema to register path to
+---@param basePath string Base path for path registrations
+---@param controllerPath string Controller path for path registrations
+function InteractiveActorLeverAnimation.registerXMLPaths(schema, basePath, controllerPath)
+    InteractiveActorLeverAnimation:superClass().registerXMLPaths(schema, basePath, controllerPath)
+
+    schema:register(XMLValueType.STRING, basePath .. "#name", "Animation name to drive as the lever visual")
+    schema:register(XMLValueType.FLOAT,  basePath .. "#neutralTime", "Animation time (0-1) to hold when not dragging — typically 0.5 for a centred lever", 0.5)
+    schema:register(XMLValueType.FLOAT,  basePath .. "#speed", "How fast the lever animation snaps to its target, in full animation lengths per second (e.g. 3.0 = reaches target in ~0.33s)", 3.0)
+end
+
+---Creates new instance of InteractiveActorLeverAnimation
+---@param modName string mod name
+---@param modDirectory string mod directory
+---@param customMt? metatable custom metatable
+---@return InteractiveActorLeverAnimation
+function InteractiveActorLeverAnimation.new(modName, modDirectory, customMt)
+    local self = InteractiveActorLeverAnimation:superClass().new(modName, modDirectory, customMt or interactiveActorLeverAnimation_mt)
+
+    self.name = nil
+    self.neutralTime = 0.5
+    self.speed = 3.0
+    self.driveSpeed = 0
+
+    return self
+end
+
+---Loads InteractiveActorLeverAnimation data from xmlFile
+---@param xmlFile XMLFile Instance of XMLFile
+---@param key string XML key to load from
+---@param target any Target vehicle
+---@param interactiveController InteractiveController Instance of InteractiveController
+---@return boolean loaded
+function InteractiveActorLeverAnimation:loadFromXML(xmlFile, key, target, interactiveController)
+    if not InteractiveActorLeverAnimation:superClass().loadFromXML(self, xmlFile, key, target, interactiveController) then
+        return false
+    end
+
+    self.name = xmlFile:getValue(key .. "#name")
+    if self.name == nil then
+        Logging.xmlWarning(xmlFile, "leverAnimation requires '#name' (animation name), ignoring actor!")
+        return false
+    end
+
+    self.neutralTime = xmlFile:getValue(key .. "#neutralTime", 0.5)
+    self.speed = xmlFile:getValue(key .. "#speed", 3.0)
+
+    return true
+end
+
+---Receives the current axis drive speed from the mouse hook each frame.
+---Called by InteractiveController:setAxisDriveSpeed which fans out to all actors with setDriveSpeed.
+---@param speed number Current mouse axis value scaled by IC sensitivity (positive or negative)
+function InteractiveActorLeverAnimation:setDriveSpeed(speed)
+    self.driveSpeed = speed
+end
+
+---Called each frame. Interpolates the lever animation toward 1.0, 0.0, or neutralTime
+---depending on the current drag direction.
+function InteractiveActorLeverAnimation:update(isIndoor, isOutdoor, hasInput)
+    if self.name == nil then return end
+
+    local targetTime
+    if self.interactiveController.isHoldActive and self.driveSpeed ~= 0 then
+        targetTime = self.driveSpeed > 0 and 1.0 or 0.0
+    else
+        targetTime = self.neutralTime
+    end
+
+    local currentTime = self.target:getAnimationTime(self.name)
+    local diff = targetTime - currentTime
+
+    if math.abs(diff) > 0.001 then
+        local step = self.speed * g_currentDt * 0.001
+        local newTime = currentTime + math.clamp(diff, -step, step)
+        self.target:setAnimationTime(self.name, newTime, true)
+    end
+
+    self.driveSpeed = 0
+end
+
+---Lever animation has no persistent state to save
+---@return boolean isSavingAllowed
+function InteractiveActorLeverAnimation:isSavingAllowed()
+    return false
+end

--- a/src/interactiveControl/interactiveActors/InteractiveActorMovingTool.lua
+++ b/src/interactiveControl/interactiveActors/InteractiveActorMovingTool.lua
@@ -1,0 +1,162 @@
+------------------------------------------------------------------------------------------------------------------------
+-- InteractiveActorMovingTool
+------------------------------------------------------------------------------------------------------------------------
+-- Purpose: Interactive actor that drives a Cylindered moving tool via axis input (mouse drag).
+--
+---@author John Deere 6930 @VertexDezign
+------------------------------------------------------------------------------------------------------------------------
+
+---@class InteractiveActorMovingTool: InteractiveActor
+InteractiveActorMovingTool = {}
+
+local interactiveActorMovingTool_mt = Class(InteractiveActorMovingTool, InteractiveActor)
+
+-- Vehicle-only; moving tools only exist on vehicles with the Cylindered specialization
+InteractiveActorMovingTool.INPUT_TYPES = { InteractiveController.INPUT_TYPES.VEHICLE }
+InteractiveActorMovingTool.KEY_NAME = "axisMovingTool"
+
+---Register AXIS_MOVING_TOOL interactive actor
+InteractiveActor.registerInteractiveActor("AXIS_MOVING_TOOL", InteractiveActorMovingTool)
+
+---Register XMLPaths to XMLSchema
+---@param schema XMLSchema Instance of XMLSchema to register path to
+---@param basePath string Base path for path registrations
+---@param controllerPath string Controller path for path registrations
+function InteractiveActorMovingTool.registerXMLPaths(schema, basePath, controllerPath)
+    InteractiveActorMovingTool:superClass().registerXMLPaths(schema, basePath, controllerPath)
+
+    schema:register(XMLValueType.NODE_INDEX, basePath .. "#node", "Moving tool node (alternative to #movingToolIndex)")
+    schema:register(XMLValueType.INT, basePath .. "#movingToolIndex", "1-based index of the moving tool in <cylindered><movingTools> (alternative to #node)")
+end
+
+---Creates new instance of InteractiveActorMovingTool
+---@param modName string mod name
+---@param modDirectory string mod directory
+---@param customMt? metatable custom metatable
+---@return InteractiveActorMovingTool
+function InteractiveActorMovingTool.new(modName, modDirectory, customMt)
+    local self = InteractiveActorMovingTool:superClass().new(modName, modDirectory, customMt or interactiveActorMovingTool_mt)
+
+    self.movingTool = nil
+    self.driveSpeed = 0
+
+    return self
+end
+
+---Loads InteractiveActorMovingTool data from xmlFile
+---@param xmlFile XMLFile Instance of XMLFile
+---@param key string XML key to load from
+---@param target any Target vehicle
+---@param interactiveController InteractiveController Instance of InteractiveController
+---@return boolean loaded
+function InteractiveActorMovingTool:loadFromXML(xmlFile, key, target, interactiveController)
+    if not InteractiveActorMovingTool:superClass().loadFromXML(self, xmlFile, key, target, interactiveController) then
+        return false
+    end
+
+    local spec = target.spec_cylindered
+    if spec == nil then
+        Logging.xmlWarning(xmlFile, "axisMovingTool requires a vehicle with the Cylindered specialization, ignoring actor!")
+        return false
+    end
+
+    -- Support two reference styles: by moving tool index (preferred) or by node name.
+    local movingToolIndex = xmlFile:getValue(key .. "#movingToolIndex")
+    if movingToolIndex ~= nil then
+        self.movingTool = spec.movingTools[movingToolIndex]
+        if self.movingTool == nil then
+            Logging.xmlWarning(xmlFile, "axisMovingTool: no moving tool at movingToolIndex=%d (vehicle has %d tools), ignoring actor!", movingToolIndex, #spec.movingTools)
+            return false
+        end
+    else
+        local node = xmlFile:getValue(key .. "#node", nil, target.components, target.i3dMappings)
+        if node == nil then
+            Logging.xmlWarning(xmlFile, "axisMovingTool requires '#movingToolIndex' or '#node', ignoring actor!")
+            return false
+        end
+        self.movingTool = target:getMovingToolByNode(node)
+        if self.movingTool == nil then
+            Logging.xmlWarning(xmlFile, "axisMovingTool: no movingTool found at the specified node, ignoring actor!")
+            return false
+        end
+    end
+
+    return true
+end
+
+---Sets the drive speed applied each frame while the axis hold is active.
+---This is the raw mouse axis value scaled by IC sensitivity, passed through the same formula
+---Cylindered uses for in-vehicle mouse input.
+---@param speed number Raw mouse axis value scaled by IC sensitivity
+function InteractiveActorMovingTool:setDriveSpeed(speed)
+    self.driveSpeed = speed
+end
+
+---Applies an input value to the moving tool using the same formula Cylindered uses for in-vehicle
+---mouse dragging: invertAxis → armSensitivity → (16.666/dt) → mouseSpeedFactor → tool.move.
+---@param inputValue number The value to apply (0 to stop the tool)
+function InteractiveActorMovingTool:applyInputToTool(inputValue)
+    local tool = self.movingTool
+    local move = tool.invertAxis and -inputValue or inputValue
+    local armSens = g_gameSettings:getValue(GameSettings.SETTING.VEHICLE_ARM_SENSITIVITY)
+    move = move * armSens
+    local mouseSpeedFactor = tool.mouseSpeedFactor or 1
+    move = move * 16.666 / g_currentDt * mouseSpeedFactor
+
+    tool.lastInputTime = g_time
+
+    if move ~= tool.move then
+        tool.move = move
+    end
+    if tool.move ~= tool.moveToSend then
+        tool.moveToSend = tool.move
+        self.target:raiseDirtyFlags(self.target.spec_cylindered.cylinderedInputDirtyFlag)
+    end
+end
+
+---Called each frame — drives the moving tool using the same formula as Cylindered's in-vehicle
+---mouse input path. driveSpeed is set by the mouse-hook each frame and is 0 when the mouse is
+---still, causing the tool to stop (matching in-vehicle behaviour).
+---Only runs on the controlling client (hasInput=true); the server receives tool.move via the
+---cylinderedInputDirtyFlag network sync and must not zero it independently.
+function InteractiveActorMovingTool:update(isIndoor, isOutdoor, hasInput)
+    if self.movingTool == nil or not hasInput then return end
+
+    if not self.interactiveController.isHoldActive then
+        if self.movingTool.move ~= 0 then
+            self:applyInputToTool(0)
+        end
+        self.driveSpeed = 0
+        return
+    end
+
+    self:applyInputToTool(self.driveSpeed)
+    self.driveSpeed = 0
+end
+
+---Returns false (with a warning popup) if requiresEngine is set on the active action and the engine is not running.
+---Called before an axis hold starts.
+---@return boolean canStart
+function InteractiveActorMovingTool:canStartHold()
+    local activeAction = self.interactiveController.activeAction
+    if activeAction ~= nil and activeAction.requiresEngine then
+        local rootVehicle = self.target.rootVehicle
+        if rootVehicle ~= nil and rootVehicle.getIsMotorStarted ~= nil and not rootVehicle:getIsMotorStarted() then
+            g_currentMission:showBlinkingWarning(g_i18n:getText("warning_motorNotStarted"), 2000)
+            return false
+        end
+    end
+    return true
+end
+
+---Moving tools do not persist state through IC's stateValue system
+---@return boolean isSavingAllowed
+function InteractiveActorMovingTool:isSavingAllowed()
+    return false
+end
+
+---Disable analog mode for moving tool actors (state value has no meaning here)
+---@return boolean isAnalogAllowed
+function InteractiveActorMovingTool:isAnalogAllowed()
+    return false
+end

--- a/src/interactiveControl/interactiveActors/InteractiveActorMovingTool.lua
+++ b/src/interactiveControl/interactiveActors/InteractiveActorMovingTool.lua
@@ -38,7 +38,9 @@ function InteractiveActorMovingTool.new(modName, modDirectory, customMt)
     local self = InteractiveActorMovingTool:superClass().new(modName, modDirectory, customMt or interactiveActorMovingTool_mt)
 
     self.movingTool = nil
+    self.movingToolIndex = nil
     self.driveSpeed = 0
+    self.hasPendingStop = false
 
     return self
 end
@@ -81,6 +83,17 @@ function InteractiveActorMovingTool:loadFromXML(xmlFile, key, target, interactiv
         end
     end
 
+    for i, t in ipairs(spec.movingTools) do
+        if t == self.movingTool then
+            self.movingToolIndex = i
+            break
+        end
+    end
+    if self.movingToolIndex == nil then
+        Logging.xmlWarning(xmlFile, "axisMovingTool: could not resolve moving tool index, ignoring actor!")
+        return false
+    end
+
     return true
 end
 
@@ -94,6 +107,9 @@ end
 
 ---Applies an input value to the moving tool using the same formula Cylindered uses for in-vehicle
 ---mouse dragging: invertAxis → armSensitivity → (16.666/dt) → mouseSpeedFactor → tool.move.
+---On a listen server the value is set directly. On a dedicated server client the value is sent to
+---the server via ICMovingToolInputEvent, because cylinderedInputDirtyFlag only syncs tools that
+---have an axisActionIndex (input-bound tools) — IC moving tools are not input-bound.
 ---@param inputValue number The value to apply (0 to stop the tool)
 function InteractiveActorMovingTool:applyInputToTool(inputValue)
     local tool = self.movingTool
@@ -103,28 +119,36 @@ function InteractiveActorMovingTool:applyInputToTool(inputValue)
     local mouseSpeedFactor = tool.mouseSpeedFactor or 1
     move = move * 16.666 / g_currentDt * mouseSpeedFactor
 
-    tool.lastInputTime = g_time
-
-    if move ~= tool.move then
+    if g_server ~= nil then
+        -- Listen server or singleplayer: set directly, Cylindered:onUpdate() picks it up this frame.
         tool.move = move
-    end
-    if tool.move ~= tool.moveToSend then
-        tool.moveToSend = tool.move
-        self.target:raiseDirtyFlags(self.target.spec_cylindered.cylinderedInputDirtyFlag)
+        tool.lastInputTime = g_time
+    else
+        -- Dedicated server client: send to server. The server's Cylindered:onUpdate() moves the
+        -- tool and syncs the position back via cylinderedDirtyFlag.
+        g_client:getServerConnection():sendEvent(ICMovingToolInputEvent.new(self.target, self.movingToolIndex, move))
+        if move ~= 0 then
+            self.hasPendingStop = true
+        end
     end
 end
 
 ---Called each frame — drives the moving tool using the same formula as Cylindered's in-vehicle
 ---mouse input path. driveSpeed is set by the mouse-hook each frame and is 0 when the mouse is
 ---still, causing the tool to stop (matching in-vehicle behaviour).
----Only runs on the controlling client (hasInput=true); the server receives tool.move via the
----cylinderedInputDirtyFlag network sync and must not zero it independently.
+---hasInput is intentionally not checked here: outdoor IC interactions run with hasInput=false
+---(the vehicle has no seated driver), but the axis hold and driveSpeed are still valid. The
+---server never calls this function (onUpdateTick guards on isClient), so no server-side guard
+---is needed. Sync to the server is handled by ICMovingToolInputEvent in applyInputToTool.
 function InteractiveActorMovingTool:update(isIndoor, isOutdoor, hasInput)
-    if self.movingTool == nil or not hasInput then return end
+    if self.movingTool == nil then return end
 
     if not self.interactiveController.isHoldActive then
-        if self.movingTool.move ~= 0 then
+        -- On listen server/singleplayer use tool.move directly; on dedicated server client use
+        -- hasPendingStop since tool.move is never set locally (only set server-side via event).
+        if self.movingTool.move ~= 0 or self.hasPendingStop then
             self:applyInputToTool(0)
+            self.hasPendingStop = false
         end
         self.driveSpeed = 0
         return

--- a/src/main.lua
+++ b/src/main.lua
@@ -24,7 +24,6 @@ local sourceFiles = {
 
     "src/misc/InteractiveControlManager.lua",
     "src/misc/InteractiveFunctions.lua",
-    "src/misc/InteractiveFunctions_externalMods.lua",
 
     -- interactiveControl
     "src/interactiveControl/InteractiveController.lua",
@@ -47,6 +46,7 @@ local sourceFiles = {
     -- network
     "src/events/ICStateEvent.lua",
     "src/events/ICStateValueEvent.lua",
+    "src/events/ICMovingToolInputEvent.lua",
 }
 
 for _, sourceFile in ipairs(sourceFiles) do

--- a/src/main.lua
+++ b/src/main.lua
@@ -33,13 +33,16 @@ local sourceFiles = {
     "src/interactiveControl/interactiveActions/InteractiveAction.lua",
     "src/interactiveControl/interactiveActions/InteractiveClickPoint.lua",
     "src/interactiveControl/interactiveActions/InteractiveButton.lua",
+    "src/interactiveControl/interactiveActions/InteractiveAxisPoint.lua",
 
     "src/interactiveControl/interactiveActors/InteractiveActor.lua",
     "src/interactiveControl/interactiveActors/InteractiveActorAnimation.lua",
+    "src/interactiveControl/interactiveActors/InteractiveActorMovingTool.lua",
+    "src/interactiveControl/interactiveActors/InteractiveActorLeverAnimation.lua",
     "src/interactiveControl/interactiveActors/InteractiveActorDependingController.lua",
     "src/interactiveControl/interactiveActors/InteractiveActorFunction.lua",
     "src/interactiveControl/interactiveActors/InteractiveActorObjectChange.lua",
-    -- "src/interactiveControl/interactiveActors/InteractiveActorDashboard.lua",
+    "src/interactiveControl/interactiveActors/InteractiveActorDashboard.lua",
 
     -- network
     "src/events/ICStateEvent.lua",
@@ -228,6 +231,46 @@ local function consoleCommandReloadVehicle(vehicleSystem, resetVehicle, radius)
     modEnvironment.injectionManager:loadInjectionXMLs()
 end
 
+---Returns true when an axis IC hold is active and the drag axis matches the given axis.
+---@param axis string "X" or "Y"
+local function isAxisHoldActive(axis)
+    return isLoaded()
+        and modEnvironment.activeController ~= nil
+        and modEnvironment.activeController.isHoldActive
+        and modEnvironment.activeController:anyActionIsAxis()
+        and modEnvironment.activeController:getAxisDragAxis() == axis
+end
+
+---Overwritten function: PlayerInputComponent.onInputLookUpDown
+---When a Y-axis IC hold is active, redirect mouse Y to the moving tool and suppress camera rotation.
+---@param inputComp PlayerInputComponent
+---@param superFunc function original function
+local function injectPlayerLookUpDown(inputComp, superFunc, actionName, inputValue, ...)
+    if isAxisHoldActive("Y") then
+        if inputValue ~= 0 then
+            local sensitivity = modEnvironment.activeController:getAxisSensitivity()
+            modEnvironment.activeController:setAxisDriveSpeed(inputValue * sensitivity)
+        end
+        return
+    end
+    return superFunc(inputComp, actionName, inputValue, ...)
+end
+
+---Overwritten function: PlayerInputComponent.onInputLookLeftRight
+---When an X-axis IC hold is active, redirect mouse X to the moving tool and suppress camera rotation.
+---@param inputComp PlayerInputComponent
+---@param superFunc function original function
+local function injectPlayerLookLeftRight(inputComp, superFunc, actionName, inputValue, ...)
+    if isAxisHoldActive("X") then
+        if inputValue ~= 0 then
+            local sensitivity = modEnvironment.activeController:getAxisSensitivity()
+            modEnvironment.activeController:setAxisDriveSpeed(inputValue * sensitivity)
+        end
+        return
+    end
+    return superFunc(inputComp, actionName, inputValue, ...)
+end
+
 ---Initialize the mod
 local function init()
     FSBaseMission.delete = Utils.appendedFunction(FSBaseMission.delete, unload)
@@ -241,6 +284,9 @@ local function init()
     XMLFile.initInheritance = Utils.prependedFunction(XMLFile.initInheritance, preInitInheritance)
     XMLFile.initInheritance = Utils.appendedFunction(XMLFile.initInheritance, postInitInheritance)
     VehicleSystem.consoleCommandReloadVehicle = Utils.prependedFunction(VehicleSystem.consoleCommandReloadVehicle, consoleCommandReloadVehicle)
+
+    PlayerInputComponent.onInputLookUpDown = Utils.overwrittenFunction(PlayerInputComponent.onInputLookUpDown, injectPlayerLookUpDown)
+    PlayerInputComponent.onInputLookLeftRight = Utils.overwrittenFunction(PlayerInputComponent.onInputLookLeftRight, injectPlayerLookLeftRight)
 
     -- AdditionalSettingsManager
     local modEnvMeta = getmetatable(_G)

--- a/src/misc/InteractiveFunctions.lua
+++ b/src/misc/InteractiveFunctions.lua
@@ -1482,3 +1482,171 @@ InteractiveFunctions.addFunction("BALEWRAPPER_TOGGLE_AUTOMATIC_DROP", {
         return true
     end
 })
+
+---FUNCTION_LIGHT_TOGGLE
+---Toggles one or more individual lights (bulb + lens) independently of the main vehicle lights system.
+---If the nodes are also referenced in <vehicle.lights>, pressing F to cycle lights will take priority
+---and overwrite the IC state on the next light change. For IC-exclusive lights, omit them from <vehicle.lights>.
+InteractiveFunctions.addFunction("LIGHT_TOGGLE", {
+    schemaFunc = function(schema, path)
+        schema:register(XMLValueType.NODE_INDEX, path .. ".realLight(?)#node",           "Real light source node (LIGHT_SOURCE class). Must NOT be in <vehicle.lights> — IC owns it exclusively via setVisibility.")
+        schema:register(XMLValueType.NODE_INDEX, path .. ".staticLightMesh(?)#node",     "Emissive mesh using the staticLight shader. Must NOT be in <staticLightCompounds> — IC owns it exclusively via lightIds shader params.")
+        schema:register(XMLValueType.FLOAT,      path .. ".staticLightMesh(?)#intensity","Emissive intensity when on (default 10). Match the intensity value you would have used on the <staticLightCompound> node.", 10)
+    end,
+    loadFunc = function(xmlFile, key, data, actor)
+        local target = actor.target
+
+        data.realLightNodes = {}
+        xmlFile:iterate(key .. ".realLight", function(_, realLightKey)
+            local node = xmlFile:getValue(realLightKey .. "#node", nil, target.components, target.i3dMappings)
+            if node ~= nil then
+                table.insert(data.realLightNodes, node)
+            else
+                Logging.xmlWarning(xmlFile, "LIGHT_TOGGLE: invalid realLight #node at '%s'", realLightKey)
+            end
+        end)
+
+        data.staticLightMeshes = {}
+        xmlFile:iterate(key .. ".staticLightMesh", function(_, meshKey)
+            local node = xmlFile:getValue(meshKey .. "#node", nil, target.components, target.i3dMappings)
+            if node == nil then
+                Logging.xmlWarning(xmlFile, "LIGHT_TOGGLE: invalid staticLightMesh #node at '%s'", meshKey)
+                return
+            end
+            if not getHasShaderParameter(node, "lightIds0") then
+                Logging.xmlWarning(xmlFile, "LIGHT_TOGGLE: staticLightMesh at '%s' is missing the lightIds0 shader parameter — ensure the node uses the staticLight shader variation", meshKey)
+                return
+            end
+            table.insert(data.staticLightMeshes, {
+                node      = node,
+                intensity = xmlFile:getValue(meshKey .. "#intensity", 10),
+            })
+        end)
+
+        if #data.realLightNodes == 0 and #data.staticLightMeshes == 0 then
+            Logging.xmlWarning(xmlFile, "LIGHT_TOGGLE has no valid nodes at '%s'", key)
+            return false
+        end
+
+        -- Apply initial off state so i3d-visible nodes match IC's default stateValue of 0.
+        for _, node in ipairs(data.realLightNodes) do
+            setVisibility(node, false)
+        end
+        for _, mesh in ipairs(data.staticLightMeshes) do
+            setShaderParameter(mesh.node, "lightIds0", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds1", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds2", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds3", 0, 0, 0, 0, false)
+        end
+
+        return true
+    end,
+    posFunc = function(target, data, noEventSend)
+        for _, node in ipairs(data.realLightNodes) do
+            setVisibility(node, true)
+        end
+        for _, mesh in ipairs(data.staticLightMeshes) do
+            local i = mesh.intensity
+            setShaderParameter(mesh.node, "lightIds0", i, i, i, i, false)
+            setShaderParameter(mesh.node, "lightIds1", i, i, i, i, false)
+            setShaderParameter(mesh.node, "lightIds2", i, i, i, i, false)
+            setShaderParameter(mesh.node, "lightIds3", i, i, i, i, false)
+        end
+    end,
+    negFunc = function(target, data, noEventSend)
+        for _, node in ipairs(data.realLightNodes) do
+            setVisibility(node, false)
+        end
+        for _, mesh in ipairs(data.staticLightMeshes) do
+            setShaderParameter(mesh.node, "lightIds0", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds1", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds2", 0, 0, 0, 0, false)
+            setShaderParameter(mesh.node, "lightIds3", 0, 0, 0, 0, false)
+        end
+    end,
+    isBlockedFunc = function(target, data)
+        return #data.realLightNodes > 0 or #data.staticLightMeshes > 0
+    end
+})
+
+-- Shared helpers for WINCH_IN / WINCH_OUT ---------------------------------------------------------
+
+local function winchSchemaFunc(schema, path)
+    schema:register(XMLValueType.VECTOR_N, path .. ".winch#ropeIndices", "Space-separated list of 1-based rope indices to control (e.g. \"1 2\" controls both ropes simultaneously)", true)
+end
+
+-- loadFunc receives the actor as 4th arg so we can cache the controller for isHoldActive checks.
+local function winchLoadFunc(xmlFile, key, data, actor)
+    data.ropeIndices = xmlFile:getValue(key .. ".winch#ropeIndices", nil, true)
+    if data.ropeIndices == nil or #data.ropeIndices == 0 then
+        Logging.xmlWarning(xmlFile, "WINCH function missing required '.winch#ropeIndices' — set at least one rope index (e.g. ropeIndices=\"1\")")
+        return false
+    end
+    if actor ~= nil then
+        data.controller = actor.interactiveController
+    end
+    return true
+end
+
+local function winchIsBlockedFunc(vehicle, data)
+    local spec = vehicle.spec_winch
+    if spec == nil or spec.ropes == nil then
+        return false
+    end
+    for _, ropeIndex in ipairs(data.ropeIndices) do
+        if spec.ropes[ropeIndex] ~= nil then
+            return true
+        end
+    end
+    return false
+end
+
+local function winchControlAll(vehicle, data, direction)
+    if vehicle.setWinchControlInput == nil then
+        return
+    end
+    for _, ropeIndex in ipairs(data.ropeIndices) do
+        vehicle:setWinchControlInput(ropeIndex, direction)
+    end
+end
+
+---FUNCTION_WINCH_IN — pulls the rope(s) in while the click point is held
+InteractiveFunctions.addFunction("WINCH_IN", {
+    schemaFunc = winchSchemaFunc,
+    loadFunc = winchLoadFunc,
+    requiresHolding = true,
+    posFunc = function(vehicle, data)
+        winchControlAll(vehicle, data, 1)
+    end,
+    negFunc = function(vehicle, data)
+        winchControlAll(vehicle, data, 0)
+    end,
+    updateFunc = function(vehicle, data)
+        -- Called every frame; keep the winch moving for as long as the hold is active.
+        if data.controller ~= nil and data.controller.isHoldActive then
+            winchControlAll(vehicle, data, 1)
+        end
+        return nil
+    end,
+    isBlockedFunc = winchIsBlockedFunc,
+})
+
+---FUNCTION_WINCH_OUT — releases the rope(s) while the click point is held
+InteractiveFunctions.addFunction("WINCH_OUT", {
+    schemaFunc = winchSchemaFunc,
+    loadFunc = winchLoadFunc,
+    requiresHolding = true,
+    posFunc = function(vehicle, data)
+        winchControlAll(vehicle, data, -1)
+    end,
+    negFunc = function(vehicle, data)
+        winchControlAll(vehicle, data, 0)
+    end,
+    updateFunc = function(vehicle, data)
+        if data.controller ~= nil and data.controller.isHoldActive then
+            winchControlAll(vehicle, data, -1)
+        end
+        return nil
+    end,
+    isBlockedFunc = winchIsBlockedFunc,
+})

--- a/src/vehicles/specializations/InteractiveControl.lua
+++ b/src/vehicles/specializations/InteractiveControl.lua
@@ -137,9 +137,6 @@ function InteractiveControl:onLoad(savegame)
     spec.interactiveTrigger = {}
     -- spec.interactiveControlDependingDashboards = {}
 
-    spec.movingToolsToInteractiveController = {}
-    spec.movingPartsToInteractiveController = {}
-
     local interactiveControlConfigurationId = Utils.getNoNil(self.configurations.interactiveControl, 1)
 
     for _, baseKey in ipairs({
@@ -156,20 +153,6 @@ function InteractiveControl:onLoad(savegame)
                 -- for _, dependingDashboard in ipairs(interactiveController.dependingDashboards) do
                 --     spec.interactiveControlDependingDashboards[dependingDashboard.identifier] = dependingDashboard
                 -- end
-
-                local dependingMovingTools = interactiveController:getMovingTools()
-                if dependingMovingTools ~= nil then
-                    for dependingMovingTool in pairs(dependingMovingTools) do
-                        spec.movingToolsToInteractiveController[dependingMovingTool] = interactiveController
-                    end
-                end
-
-                local dependingMovingParts = interactiveController:getMovingParts()
-                if dependingMovingParts ~= nil then
-                    for dependingMovingPart in pairs(dependingMovingParts) do
-                        spec.movingPartsToInteractiveController[dependingMovingPart] = interactiveController
-                    end
-                end
             else
                 interactiveController:delete()
                 Logging.xmlWarning(self.xmlFile, "Could not load InteractiveController for '%s'", interactiveControlKey)
@@ -183,7 +166,6 @@ function InteractiveControl:onLoad(savegame)
     spec.maxUpdateTime = 0
 
     spec.indoorSoundModifierFactor = InteractiveControl.SOUND_FALLBACK
-    spec.pendingSoundControls = {}
 end
 
 ---Called after load
@@ -319,7 +301,7 @@ function InteractiveControl:onUpdateTick(dt, isActiveForInput, isActiveForInputI
 
     if isOutdoor then
         self:updateInteractiveController(isIndoor, isOutdoor, isActiveForInputIgnoreSelection)
-    elseif g_noHudModeEnabled and isIndoor or isOutdoor then
+    elseif g_noHudModeEnabled and isIndoor then
         self:updateInteractiveController(isIndoor, isOutdoor, isActiveForInputIgnoreSelection)
     elseif not isOutdoor and not isIndoor or not self:isInteractiveControlActivated() then
         self:updateInteractiveController(false, false, isActiveForInputIgnoreSelection)
@@ -383,6 +365,7 @@ function InteractiveControl:updateInteractiveController(isIndoor, isOutdoor, has
 
     ---@type InteractiveController
     local activeController
+    local activeControllerDistSq = math.huge
 
     for _, interactiveController in pairs(spec.interactiveControllers) do
         ---@cast interactiveController InteractiveController
@@ -390,7 +373,11 @@ function InteractiveControl:updateInteractiveController(isIndoor, isOutdoor, has
 
         local activeAction = interactiveController:updateActiveAction()
         if activeAction ~= nil then
-            activeController = interactiveController
+            local distSq = interactiveController:getActiveActionDistSq()
+            if distSq < activeControllerDistSq then
+                activeController = interactiveController
+                activeControllerDistSq = distSq
+            end
         end
     end
 
@@ -839,10 +826,9 @@ end
 function InteractiveControl:getIsMovingToolActive(superFunc, movingTool)
     local spec = self.spec_interactiveControl
 
-    ---@type InteractiveController
-    local interactiveController = spec.movingToolsToInteractiveController[movingTool]
-    if interactiveController ~= nil then
-        if interactiveController:getMovingToolIsInactive(movingTool) then
+    for _, interactiveController in pairs(spec.interactiveControllers) do
+        ---@cast interactiveController InteractiveController
+        if interactiveController:hasDependingMovingTools() and interactiveController:getMovingToolIsInactive(movingTool) then
             return false
         end
     end
@@ -856,10 +842,9 @@ end
 function InteractiveControl:getIsMovingPartActive(superFunc, movingPart)
     local spec = self.spec_interactiveControl
 
-    ---@type InteractiveController
-    local interactiveController = spec.movingPartsToInteractiveController[movingPart]
-    if interactiveController ~= nil then
-        if interactiveController:getMovingPartIsInactive(movingPart) then
+    for _, interactiveController in pairs(spec.interactiveControllers) do
+        ---@cast interactiveController InteractiveController
+        if interactiveController:hasDependingMovingParts() and interactiveController:getMovingPartIsInactive(movingPart) then
             return false
         end
     end


### PR DESCRIPTION
## Summary

This PR implements several new features, fixes, and cleanup changes developed against the `develop` branch.

### New Features

**Axis-drag moving tool system**
- New `axisPoint` action: locks the player camera while the mouse is held, capturing vertical mouse delta as an axis value
- New `axisMovingTool` actor: drives a cylindered moving tool directly from the captured axis (replaces the old IC_AXIS_DRIVE action, which was dead code)
- New `leverAnimation` actor: plays a blend animation in sync with the axis value for a physical lever visual

**WINCH_IN / WINCH_OUT functions**
- Hold-to-activate functions for winch control
- Uses the existing `InteractiveFunction` infrastructure

**LIGHT_TOGGLE function**
- IC-exclusive per-light toggle independent of the vehicle lighting system
- Controls both real light nodes and static mesh emissive shader parameters
- Applies off-state on initial load so lights match IC default state (stateValue=0) on first spawn

**`requireHolding` attribute for clickPoints**
- Any `<clickPoint>` can now specify `requireHolding="true"` to require the player to hold the interact key rather than tap it
- Applies to all IC controllers, not just winches
- Useful for any action where accidental activation would be undesirable

### Fixes

- Fixed dedicated server bug: `InteractiveActorMovingTool:update()` was zeroing `tool.move` on every frame on the server (because `hasInput=false`), cancelling the move value the client had already sent. Added `if not hasInput then return end` guard.
- Fixed `LIGHT_TOGGLE` initial state: real light nodes were visible on first vehicle spawn because IC never called `negFunc` on load. Fixed by applying the off-state explicitly in `loadFunc`.
- Re-enabled `InteractiveActorDashboard` (was commented out of the source list in main.lua).

### Locale Fixes

Corrected untranslated strings that were left as English in non-English locales:

- **BR**: `actionIC_radioOn`, `actionIC_radioOff`
- **FR**: `settingsIC_state_option01`
- **IT**: `actionIC_radioOn`, `actionIC_radioOff`
- **PL**: `actionIC_radioOn`, `actionIC_radioOff`

### Documentation

Added `XML_REFERENCE.md` — a comprehensive reference document covering all IC XML configuration elements, attributes, and examples. Covers:
- `<interactiveControl>` vehicle spec root
- All `<controller>` types with their attributes
- All `<clickPoint>` attributes including the new `requireHolding`
- All `<actor>` types: `animation`, `function`, `objectChange`, `movingTool`, `axisMovingTool`, `leverAnimation`, `dashboard`
- All supported `InteractiveFunction` names
- The new `axisPoint` action configuration
- Examples for the new axis-drag and winch workflows